### PR TITLE
Add PUT/PATCH/DELETE for zaakobjecten

### DIFF
--- a/src/notificaties.md
+++ b/src/notificaties.md
@@ -33,7 +33,7 @@ De architectuur van de notificaties staat beschreven op <a href="https://github.
 
 * <code>status</code>: create
 
-* <code>zaakobject</code>: create
+* <code>zaakobject</code>: create, update, destroy
 
 * <code>zaakinformatieobject</code>: create
 

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -72,7 +72,7 @@ info:
 
     - `status`: create
 
-    - `zaakobject`: create
+    - `zaakobject`: create, update, destroy
 
     - `zaakinformatieobject`: create
 
@@ -2329,7 +2329,10 @@ paths:
     post:
       operationId: zaakobject_create
       summary: Maak een ZAAKOBJECT aan.
-      description: Maak een ZAAKOBJECT aan.
+      description: "Maak een ZAAKOBJECT aan.\n\n**Er wordt gevalideerd op**\n\n- Indien\
+        \ de `object` URL opgegeveven is, dan moet deze een geldige response\n  (HTTP\
+        \ 200) geven.\n- Indien opgegeven, dan wordt `objectIdentificatie` gevalideerd\
+        \ tegen de\n  `objectType` discriminator."
       parameters:
       - name: Content-Type
         in: header
@@ -2352,11 +2355,7 @@ paths:
         schema:
           type: string
       requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ZaakObject'
-        required: true
+        $ref: '#/components/requestBodies/ZaakObject'
       responses:
         '201':
           description: Created
@@ -2465,6 +2464,155 @@ paths:
       security:
       - JWT-Claims:
         - zaken.lezen
+    put:
+      operationId: zaakobject_update
+      summary: Werk een ZAAKOBJECT in zijn geheel bij.
+      description: "**Er wordt gevalideerd op**\n\n- De attributen `zaak`, `object`\
+        \ en `objectType` mogen niet gewijzigd worden.\n- Indien opgegeven, dan wordt\
+        \ `objectIdentificatie` gevalideerd tegen de\n  `objectType` discriminator."
+      parameters:
+      - name: Content-Type
+        in: header
+        description: Content type van de verzoekinhoud.
+        required: true
+        schema:
+          type: string
+          enum:
+          - application/json
+      requestBody:
+        $ref: '#/components/requestBodies/ZaakObject'
+      responses:
+        '200':
+          description: OK
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakObject'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '406':
+          $ref: '#/components/responses/406'
+        '409':
+          $ref: '#/components/responses/409'
+        '410':
+          $ref: '#/components/responses/410'
+        '415':
+          $ref: '#/components/responses/415'
+        '429':
+          $ref: '#/components/responses/429'
+        '500':
+          $ref: '#/components/responses/500'
+      tags:
+      - zaakobjecten
+      security:
+      - JWT-Claims:
+        - (zaken.bijwerken | zaken.geforceerd-bijwerken)
+    patch:
+      operationId: zaakobject_partial_update
+      summary: Werk een ZAAKOBJECT deels bij.
+      description: "**Er wordt gevalideerd op**\n\n- De attributen `zaak`, `object`\
+        \ en `objectType` mogen niet gewijzigd worden.\n- Indien opgegeven, dan wordt\
+        \ `objectIdentificatie` gevalideerd tegen de\n  `objectType` discriminator."
+      parameters:
+      - name: Content-Type
+        in: header
+        description: Content type van de verzoekinhoud.
+        required: true
+        schema:
+          type: string
+          enum:
+          - application/json
+      requestBody:
+        $ref: '#/components/requestBodies/ZaakObject'
+      responses:
+        '200':
+          description: OK
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZaakObject'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '406':
+          $ref: '#/components/responses/406'
+        '409':
+          $ref: '#/components/responses/409'
+        '410':
+          $ref: '#/components/responses/410'
+        '415':
+          $ref: '#/components/responses/415'
+        '429':
+          $ref: '#/components/responses/429'
+        '500':
+          $ref: '#/components/responses/500'
+      tags:
+      - zaakobjecten
+      security:
+      - JWT-Claims:
+        - (zaken.bijwerken | zaken.geforceerd-bijwerken)
+    delete:
+      operationId: zaakobject_delete
+      summary: Verwijder een ZAAKOBJECT.
+      description: 'Verbreek de relatie tussen een ZAAK en een OBJECT door de ZAAKOBJECT
+        resource te
+
+        verwijderen.'
+      responses:
+        '204':
+          description: No content
+          headers:
+            API-version:
+              schema:
+                type: string
+              description: 'Geeft een specifieke API-versie aan in de context van
+                een specifieke aanroep. Voorbeeld: 1.2.1.'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '406':
+          $ref: '#/components/responses/406'
+        '409':
+          $ref: '#/components/responses/409'
+        '410':
+          $ref: '#/components/responses/410'
+        '415':
+          $ref: '#/components/responses/415'
+        '429':
+          $ref: '#/components/responses/429'
+        '500':
+          $ref: '#/components/responses/500'
+      tags:
+      - zaakobjecten
+      security:
+      - JWT-Claims:
+        - (zaken.bijwerken | zaken.geforceerd-bijwerken | zaken.verwijderen)
     parameters:
     - name: uuid
       in: path
@@ -4637,6 +4785,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ZaakInformatieObject'
+      required: true
+    ZaakObject:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ZaakObject'
       required: true
     Zaak:
       content:

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -2,7 +2,7 @@
     "swagger": "2.0",
     "info": {
         "title": "Zaken API",
-        "description": "Een API om een zaakregistratiecomponent (ZRC) te benaderen.\n\nDe ZAAK is het kernobject in deze API, waaraan verschillende andere\nresources gerelateerd zijn. De Zaken API werkt samen met andere API's voor\nZaakgericht werken om tot volledige functionaliteit te komen.\n\n**Afhankelijkheden**\n\nDeze API is afhankelijk van:\n\n* Catalogi API\n* Notificaties API\n* Documenten API *(optioneel)*\n* Besluiten API *(optioneel)*\n* Autorisaties API *(optioneel)*\n\n**Autorisatie**\n\nDeze API vereist autorisatie. Je kan de\n[token-tool](https://zaken-auth.vng.cloud/) gebruiken om JWT-tokens te\ngenereren.\n\n### Notificaties\n\nDeze API publiceert notificaties op het kanaal `zaken`.\n\n**Main resource**\n\n`zaak`\n\n\n\n**Kenmerken**\n\n* `bronorganisatie`: Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die de zaak heeft gecreeerd. Dit moet een geldig RSIN zijn van 9 nummers en voldoen aan https://nl.wikipedia.org/wiki/Burgerservicenummer#11-proef\n* `zaaktype`: URL-referentie naar het ZAAKTYPE (in de Catalogi API) in de CATALOGUS waar deze voorkomt\n* `vertrouwelijkheidaanduiding`: Aanduiding van de mate waarin het zaakdossier van de ZAAK voor de openbaarheid bestemd is.\n\n**Resources en acties**\n- `zaak`: create, update, destroy\n- `status`: create\n- `zaakobject`: create\n- `zaakinformatieobject`: create\n- `zaakeigenschap`: create, update, destroy\n- `klantcontact`: create\n- `rol`: create, destroy\n- `resultaat`: create, update, destroy\n- `zaakbesluit`: create\n- `zaakcontactmoment`: create\n- `zaakverzoek`: create\n\n\n**Handige links**\n\n* [Documentatie](https://vng-realisatie.github.io/gemma-zaken/standaard)\n* [Zaakgericht werken](https://vng-realisatie.github.io/gemma-zaken)\n",
+        "description": "Een API om een zaakregistratiecomponent (ZRC) te benaderen.\n\nDe ZAAK is het kernobject in deze API, waaraan verschillende andere\nresources gerelateerd zijn. De Zaken API werkt samen met andere API's voor\nZaakgericht werken om tot volledige functionaliteit te komen.\n\n**Afhankelijkheden**\n\nDeze API is afhankelijk van:\n\n* Catalogi API\n* Notificaties API\n* Documenten API *(optioneel)*\n* Besluiten API *(optioneel)*\n* Autorisaties API *(optioneel)*\n\n**Autorisatie**\n\nDeze API vereist autorisatie. Je kan de\n[token-tool](https://zaken-auth.vng.cloud/) gebruiken om JWT-tokens te\ngenereren.\n\n### Notificaties\n\nDeze API publiceert notificaties op het kanaal `zaken`.\n\n**Main resource**\n\n`zaak`\n\n\n\n**Kenmerken**\n\n* `bronorganisatie`: Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die de zaak heeft gecreeerd. Dit moet een geldig RSIN zijn van 9 nummers en voldoen aan https://nl.wikipedia.org/wiki/Burgerservicenummer#11-proef\n* `zaaktype`: URL-referentie naar het ZAAKTYPE (in de Catalogi API) in de CATALOGUS waar deze voorkomt\n* `vertrouwelijkheidaanduiding`: Aanduiding van de mate waarin het zaakdossier van de ZAAK voor de openbaarheid bestemd is.\n\n**Resources en acties**\n- `zaak`: create, update, destroy\n- `status`: create\n- `zaakobject`: create, update, destroy\n- `zaakinformatieobject`: create\n- `zaakeigenschap`: create, update, destroy\n- `klantcontact`: create\n- `rol`: create, destroy\n- `resultaat`: create, update, destroy\n- `zaakbesluit`: create\n- `zaakcontactmoment`: create\n- `zaakverzoek`: create\n\n\n**Handige links**\n\n* [Documentatie](https://vng-realisatie.github.io/gemma-zaken/standaard)\n* [Zaakgericht werken](https://vng-realisatie.github.io/gemma-zaken)\n",
         "contact": {
             "url": "https://vng-realisatie.github.io/gemma-zaken",
             "email": "standaarden.ondersteuning@vng.nl"
@@ -2927,7 +2927,7 @@
             "post": {
                 "operationId": "zaakobject_create",
                 "summary": "Maak een ZAAKOBJECT aan.",
-                "description": "Maak een ZAAKOBJECT aan.",
+                "description": "Maak een ZAAKOBJECT aan.\n\n**Er wordt gevalideerd op**\n\n- Indien de `object` URL opgegeveven is, dan moet deze een geldige response\n  (HTTP 200) geven.\n- Indien opgegeven, dan wordt `objectIdentificatie` gevalideerd tegen de\n  `objectType` discriminator.",
                 "parameters": [
                     {
                         "name": "Content-Type",
@@ -3103,6 +3103,224 @@
                     {
                         "JWT-Claims": [
                             "zaken.lezen"
+                        ]
+                    }
+                ]
+            },
+            "put": {
+                "operationId": "zaakobject_update",
+                "summary": "Werk een ZAAKOBJECT in zijn geheel bij.",
+                "description": "**Er wordt gevalideerd op**\n\n- De attributen `zaak`, `object` en `objectType` mogen niet gewijzigd worden.\n- Indien opgegeven, dan wordt `objectIdentificatie` gevalideerd tegen de\n  `objectType` discriminator.",
+                "parameters": [
+                    {
+                        "name": "Content-Type",
+                        "in": "header",
+                        "description": "Content type van de verzoekinhoud.",
+                        "required": true,
+                        "type": "string",
+                        "enum": [
+                            "application/json"
+                        ]
+                    },
+                    {
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/ZaakObject"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ZaakObject"
+                        },
+                        "headers": {
+                            "API-version": {
+                                "schema": {
+                                    "type": "string"
+                                },
+                                "description": "Geeft een specifieke API-versie aan in de context van een specifieke aanroep. Voorbeeld: 1.2.1."
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/responses/400"
+                    },
+                    "401": {
+                        "$ref": "#/responses/401"
+                    },
+                    "403": {
+                        "$ref": "#/responses/403"
+                    },
+                    "404": {
+                        "$ref": "#/responses/404"
+                    },
+                    "406": {
+                        "$ref": "#/responses/406"
+                    },
+                    "409": {
+                        "$ref": "#/responses/409"
+                    },
+                    "410": {
+                        "$ref": "#/responses/410"
+                    },
+                    "415": {
+                        "$ref": "#/responses/415"
+                    },
+                    "429": {
+                        "$ref": "#/responses/429"
+                    },
+                    "500": {
+                        "$ref": "#/responses/500"
+                    }
+                },
+                "tags": [
+                    "zaakobjecten"
+                ],
+                "security": [
+                    {
+                        "JWT-Claims": [
+                            "(zaken.bijwerken | zaken.geforceerd-bijwerken)"
+                        ]
+                    }
+                ]
+            },
+            "patch": {
+                "operationId": "zaakobject_partial_update",
+                "summary": "Werk een ZAAKOBJECT deels bij.",
+                "description": "**Er wordt gevalideerd op**\n\n- De attributen `zaak`, `object` en `objectType` mogen niet gewijzigd worden.\n- Indien opgegeven, dan wordt `objectIdentificatie` gevalideerd tegen de\n  `objectType` discriminator.",
+                "parameters": [
+                    {
+                        "name": "Content-Type",
+                        "in": "header",
+                        "description": "Content type van de verzoekinhoud.",
+                        "required": true,
+                        "type": "string",
+                        "enum": [
+                            "application/json"
+                        ]
+                    },
+                    {
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/ZaakObject"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ZaakObject"
+                        },
+                        "headers": {
+                            "API-version": {
+                                "schema": {
+                                    "type": "string"
+                                },
+                                "description": "Geeft een specifieke API-versie aan in de context van een specifieke aanroep. Voorbeeld: 1.2.1."
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/responses/400"
+                    },
+                    "401": {
+                        "$ref": "#/responses/401"
+                    },
+                    "403": {
+                        "$ref": "#/responses/403"
+                    },
+                    "404": {
+                        "$ref": "#/responses/404"
+                    },
+                    "406": {
+                        "$ref": "#/responses/406"
+                    },
+                    "409": {
+                        "$ref": "#/responses/409"
+                    },
+                    "410": {
+                        "$ref": "#/responses/410"
+                    },
+                    "415": {
+                        "$ref": "#/responses/415"
+                    },
+                    "429": {
+                        "$ref": "#/responses/429"
+                    },
+                    "500": {
+                        "$ref": "#/responses/500"
+                    }
+                },
+                "tags": [
+                    "zaakobjecten"
+                ],
+                "security": [
+                    {
+                        "JWT-Claims": [
+                            "(zaken.bijwerken | zaken.geforceerd-bijwerken)"
+                        ]
+                    }
+                ]
+            },
+            "delete": {
+                "operationId": "zaakobject_delete",
+                "summary": "Verwijder een ZAAKOBJECT.",
+                "description": "Verbreek de relatie tussen een ZAAK en een OBJECT door de ZAAKOBJECT resource te\nverwijderen.",
+                "parameters": [],
+                "responses": {
+                    "204": {
+                        "description": "No content",
+                        "headers": {
+                            "API-version": {
+                                "schema": {
+                                    "type": "string"
+                                },
+                                "description": "Geeft een specifieke API-versie aan in de context van een specifieke aanroep. Voorbeeld: 1.2.1."
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#/responses/401"
+                    },
+                    "403": {
+                        "$ref": "#/responses/403"
+                    },
+                    "404": {
+                        "$ref": "#/responses/404"
+                    },
+                    "406": {
+                        "$ref": "#/responses/406"
+                    },
+                    "409": {
+                        "$ref": "#/responses/409"
+                    },
+                    "410": {
+                        "$ref": "#/responses/410"
+                    },
+                    "415": {
+                        "$ref": "#/responses/415"
+                    },
+                    "429": {
+                        "$ref": "#/responses/429"
+                    },
+                    "500": {
+                        "$ref": "#/responses/500"
+                    }
+                },
+                "tags": [
+                    "zaakobjecten"
+                ],
+                "security": [
+                    {
+                        "JWT-Claims": [
+                            "(zaken.bijwerken | zaken.geforceerd-bijwerken | zaken.verwijderen)"
                         ]
                     }
                 ]

--- a/src/zrc/api/serializers/core.py
+++ b/src/zrc/api/serializers/core.py
@@ -760,11 +760,17 @@ class ZaakObjectSerializer(PolymorphicSerializer):
         extra_kwargs = {
             "url": {"lookup_field": "uuid"},
             "uuid": {"read_only": True},
-            "zaak": {"lookup_field": "uuid"},
+            "zaak": {
+                "lookup_field": "uuid",
+                "validators": [IsImmutableValidator()]
+            },
             "object": {
                 "required": False,
-                "validators": [URLValidator(get_auth=get_auth)],
+                "validators": [URLValidator(get_auth=get_auth), IsImmutableValidator()],
             },
+            "object_type": {
+                "validators": [IsImmutableValidator()],
+            }
         }
         validators = [
             EitherFieldRequiredValidator(

--- a/src/zrc/api/serializers/core.py
+++ b/src/zrc/api/serializers/core.py
@@ -760,23 +760,21 @@ class ZaakObjectSerializer(PolymorphicSerializer):
         extra_kwargs = {
             "url": {"lookup_field": "uuid"},
             "uuid": {"read_only": True},
-            "zaak": {
-                "lookup_field": "uuid",
-                "validators": [IsImmutableValidator()]
-            },
+            "zaak": {"lookup_field": "uuid", "validators": [IsImmutableValidator()]},
             "object": {
                 "required": False,
                 "validators": [URLValidator(get_auth=get_auth), IsImmutableValidator()],
             },
             "object_type": {
                 "validators": [IsImmutableValidator()],
-            }
+            },
         }
         validators = [
             EitherFieldRequiredValidator(
                 fields=("object", "object_identificatie"),
                 message=_("object or objectIdentificatie must be provided"),
                 code="invalid-zaakobject",
+                skip_for_updates=True,
             ),
             ObjectTypeOverigeDefinitieValidator(),
         ]
@@ -789,7 +787,10 @@ class ZaakObjectSerializer(PolymorphicSerializer):
 
     def validate(self, attrs):
         validated_attrs = super().validate(attrs)
-        object_identificatie = validated_attrs.get("object_identificatie", None)
+
+        # for update don't validate fields, cause most of them are immutable
+        if self.instance:
+            return validated_attrs
 
         object_type = validated_attrs.get("object_type", None)
         object_type_overige = validated_attrs.get("object_type_overige", None)
@@ -820,6 +821,13 @@ class ZaakObjectSerializer(PolymorphicSerializer):
 
         return validated_attrs
 
+    def to_internal_value(self, data):
+        # add object_type to data for PATCH
+        if self.instance and "object_type" not in data:
+            data["object_type"] = self.instance.object_type
+
+        return super().to_internal_value(data)
+
     @transaction.atomic
     def create(self, validated_data):
         group_data = validated_data.pop("object_identificatie", None)
@@ -828,6 +836,23 @@ class ZaakObjectSerializer(PolymorphicSerializer):
         if group_data:
             group_serializer = self.discriminator.mapping[validated_data["object_type"]]
             serializer = group_serializer.get_fields()["object_identificatie"]
+            group_data["zaakobject"] = zaakobject
+            serializer.create(group_data)
+
+        return zaakobject
+
+    @transaction.atomic
+    def update(self, instance, validated_data):
+        group_data = validated_data.pop("object_identificatie", None)
+        zaakobject = super().update(instance, validated_data)
+
+        if group_data:
+            group_serializer = self.discriminator.mapping[instance.object_type]
+            serializer = group_serializer.get_fields()["object_identificatie"]
+            # remove the previous data
+            model = serializer.Meta.model
+            model.objects.filter(zaakobject=zaakobject).delete()
+
             group_data["zaakobject"] = zaakobject
             serializer.create(group_data)
 

--- a/src/zrc/api/tests/test_zaakobject.py
+++ b/src/zrc/api/tests/test_zaakobject.py
@@ -83,7 +83,7 @@ class ZaakObjectBaseTestCase(JWTAuthMixin, APITestCase):
 
         self.assertEqual(zaakobject.object, OBJECT)
 
-    def test_create_rol_fail_validation(self):
+    def test_create_zaakobject_fail_validation(self):
         url = get_operation_url("zaakobject_create")
         zaak = ZaakFactory.create()
         zaak_url = get_operation_url("zaak_read", uuid=zaak.uuid)
@@ -100,6 +100,49 @@ class ZaakObjectBaseTestCase(JWTAuthMixin, APITestCase):
         validation_error = get_validation_errors(response, "nonFieldErrors")
         self.assertEqual(validation_error["code"], "invalid-zaakobject")
 
+    def test_update_zaakobject(self):
+        zaak = ZaakFactory.create()
+        zaakobject = ZaakObjectFactory.create(
+            zaak=zaak, object=OBJECT, object_type=ZaakobjectTypes.besluit
+        )
+        url = get_operation_url("zaakobject_update", uuid=zaakobject.uuid)
+        data = {"relatieomschrijving": "new"}
+
+        response = self.client.patch(url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        zaakobject.refresh_from_db()
+
+        self.assertEqual(zaakobject.relatieomschrijving, "new")
+
+    def test_update_zaakobject_fail_immuitable_field(self):
+        zaak = ZaakFactory.create()
+        zaakobject = ZaakObjectFactory.create(
+            zaak=zaak, object=OBJECT, object_type=ZaakobjectTypes.besluit
+        )
+        url = get_operation_url("zaakobject_update", uuid=zaakobject.uuid)
+        data = {"objectType": ZaakobjectTypes.adres}
+
+        response = self.client.patch(url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        validation_error = get_validation_errors(response, "objectType")
+        self.assertEqual(validation_error["code"], "wijzigen-niet-toegelaten")
+
+    def test_delete_zaakobject(self):
+        zaak = ZaakFactory.create()
+        zaakobject = ZaakObjectFactory.create(
+            zaak=zaak, object=OBJECT, object_type=ZaakobjectTypes.besluit
+        )
+        url = get_operation_url("zaakobject_read", uuid=zaakobject.uuid)
+
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(ZaakObject.objects.count(), 0)
+
 
 class ZaakObjectAdresTestCase(JWTAuthMixin, APITestCase):
     """
@@ -109,7 +152,6 @@ class ZaakObjectAdresTestCase(JWTAuthMixin, APITestCase):
     heeft_alle_autorisaties = True
 
     def test_read_zaakobject_adres(self):
-
         zaak = ZaakFactory.create()
         zaakobject = ZaakObjectFactory.create(
             zaak=zaak, object="", object_type=ZaakobjectTypes.adres
@@ -185,6 +227,60 @@ class ZaakObjectAdresTestCase(JWTAuthMixin, APITestCase):
 
         self.assertEqual(zaakobject.adres, adres)
         self.assertEqual(adres.identificatie, "123456")
+
+    def test_update_zaakobject_adres(self):
+        zaak = ZaakFactory.create()
+        zaakobject = ZaakObjectFactory.create(
+            zaak=zaak, object="", object_type=ZaakobjectTypes.adres
+        )
+        Adres.objects.create(
+            zaakobject=zaakobject,
+            identificatie="old",
+            wpl_woonplaats_naam="old city",
+            gor_openbare_ruimte_naam="old space",
+            huisnummer=1,
+        )
+
+        url = get_operation_url("zaakobject_read", uuid=zaakobject.uuid)
+        data = {
+            "objectIdentificatie": {
+                "identificatie": "new",
+                "wplWoonplaatsNaam": "new city",
+                "gorOpenbareRuimteNaam": "new space",
+                "huisnummer": 2,
+            }
+        }
+
+        response = self.client.patch(url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        zaakobject.refresh_from_db()
+        adres = zaakobject.adres
+
+        self.assertEqual(adres.identificatie, "new")
+        self.assertEqual(adres.wpl_woonplaats_naam, "new city")
+        self.assertEqual(adres.gor_openbare_ruimte_naam, "new space")
+        self.assertEqual(adres.huisnummer, 2)
+
+    def test_delete_zaakobject(self):
+        zaak = ZaakFactory.create()
+        zaakobject = ZaakObjectFactory.create(
+            zaak=zaak, object="", object_type=ZaakobjectTypes.adres
+        )
+        Adres.objects.create(
+            zaakobject=zaakobject,
+            identificatie="old",
+            wpl_woonplaats_naam="old city",
+            gor_openbare_ruimte_naam="old space",
+            huisnummer=1,
+        )
+        url = get_operation_url("zaakobject_read", uuid=zaakobject.uuid)
+
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(ZaakObject.objects.count(), 0)
 
 
 class ZaakObjectHuishoudenTestCase(JWTAuthMixin, APITestCase):
@@ -375,6 +471,30 @@ class ZaakObjectMedewerkerTestCase(JWTAuthMixin, APITestCase):
 
         self.assertEqual(zaakobject.medewerker, medewerker)
         self.assertEqual(medewerker.identificatie, "123456")
+
+    def test_update_zaakobject_medewerker(self):
+        zaak = ZaakFactory.create()
+        zaakobject = ZaakObjectFactory.create(
+            zaak=zaak, object="", object_type=ZaakobjectTypes.medewerker
+        )
+        Medewerker.objects.create(
+            zaakobject=zaakobject,
+            identificatie="old",
+        )
+
+        url = get_operation_url("zaakobject_read", uuid=zaakobject.uuid)
+        data = {
+            "objectIdentificatie": {
+                "identificatie": "new",
+            }
+        }
+
+        response = self.client.patch(url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        zaakobject.refresh_from_db()
+        self.assertEqual(zaakobject.medewerker.identificatie, "new")
 
 
 class ZaakObjectTerreinGebouwdObjectTestCase(JWTAuthMixin, APITestCase):
@@ -579,6 +699,45 @@ class ZaakObjectWozObjectTestCase(JWTAuthMixin, APITestCase):
         self.assertEqual(wozobject.woz_object_nummer, "12345")
         self.assertEqual(wozobject.aanduiding_woz_object, adres)
         self.assertEqual(adres.identificatie, "a")
+
+    def test_update_zaakobject_wozObject(self):
+        zaak = ZaakFactory.create()
+        zaakobject = ZaakObjectFactory.create(
+            zaak=zaak, object="", object_type=ZaakobjectTypes.woz_object
+        )
+        wozobject = WozObject.objects.create(
+            zaakobject=zaakobject, woz_object_nummer="12345"
+        )
+        Adres.objects.create(
+            wozobject=wozobject,
+            identificatie="old",
+            wpl_woonplaats_naam="old city",
+            gor_openbare_ruimte_naam="old space",
+            huisnummer="11",
+        )
+
+        url = get_operation_url("zaakobject_read", uuid=zaakobject.uuid)
+        data = {
+            "objectIdentificatie": {
+                "wozObjectNummer": "6789",
+                "aanduidingWozObject": {
+                    "aoaIdentificatie": "new",
+                    "wplWoonplaatsNaam": "new city",
+                    "gorOpenbareRuimteNaam": "new space",
+                    "aoaHuisnummer": 22,
+                },
+            }
+        }
+
+        response = self.client.patch(url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        zaakobject.refresh_from_db()
+        wozobject = zaakobject.wozobject
+
+        self.assertEqual(wozobject.woz_object_nummer, "6789")
+        self.assertEqual(wozobject.aanduiding_woz_object.identificatie, "new")
 
 
 class ZaakObjectWozDeelobjectTestCase(JWTAuthMixin, APITestCase):
@@ -944,6 +1103,48 @@ class ZaakObjectZakelijkRechtTestCase(JWTAuthMixin, APITestCase):
             "123456",
         )
 
+    def test_update_zaakobject_zakelijkRecht(self):
+        zaak = ZaakFactory.create()
+        zaakobject = ZaakObjectFactory.create(
+            zaak=zaak, object="", object_type=ZaakobjectTypes.zakelijk_recht
+        )
+        zakelijk_recht = ZakelijkRecht.objects.create(
+            zaakobject=zaakobject, identificatie="12345", avg_aard="old"
+        )
+        KadastraleOnroerendeZaak.objects.create(
+            zakelijk_recht=zakelijk_recht,
+            kadastrale_identificatie="1",
+            kadastrale_aanduiding="old",
+        )
+
+        url = get_operation_url("zaakobject_read", uuid=zaakobject.uuid)
+        data = {
+            "objectIdentificatie": {
+                "identificatie": "6789",
+                "avgAard": "new",
+                "heeftBetrekkingOp": {
+                    "kadastraleIdentificatie": "2",
+                    "kadastraleAanduiding": "new",
+                },
+            }
+        }
+
+        response = self.client.patch(url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        zaakobject.refresh_from_db()
+        zakelijk_recht = zaakobject.zakelijkrecht
+
+        self.assertEqual(zakelijk_recht.identificatie, "6789")
+        self.assertEqual(zakelijk_recht.avg_aard, "new")
+        self.assertEqual(
+            zakelijk_recht.heeft_betrekking_op.kadastrale_identificatie, "2"
+        )
+        self.assertEqual(
+            zakelijk_recht.heeft_betrekking_op.kadastrale_aanduiding, "new"
+        )
+
 
 class ZaakObjectOverigeTestCase(JWTAuthMixin, APITestCase):
     """
@@ -1071,6 +1272,43 @@ class ZaakObjectOverigeTestCase(JWTAuthMixin, APITestCase):
         )
         error = get_validation_errors(response, "nonFieldErrors")
         self.assertEqual(error["code"], "invalid-object-type-overige-usage")
+
+    def test_update_zaakobject_overige(self):
+        zaak = ZaakFactory.create()
+        zaakobject = ZaakObjectFactory.create(
+            zaak=zaak, object="", object_type=ZaakobjectTypes.overige
+        )
+        Overige.objects.create(
+            zaakobject=zaakobject, overige_data={"some_field": "old value"}
+        )
+
+        url = get_operation_url("zaakobject_read", uuid=zaakobject.uuid)
+        data = {"objectIdentificatie": {"overigeData": {"someField": "new value"}}}
+
+        response = self.client.patch(url, data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        zaakobject.refresh_from_db()
+        overige = zaakobject.overige
+
+        self.assertEqual(overige.overige_data, {"some_field": "new value"})
+
+    def test_delete_zaakobject_overige(self):
+        zaak = ZaakFactory.create()
+        zaakobject = ZaakObjectFactory.create(
+            zaak=zaak, object="", object_type=ZaakobjectTypes.overige
+        )
+        Overige.objects.create(
+            zaakobject=zaakobject, overige_data={"some_field": "some value"}
+        )
+
+        url = get_operation_url("zaakobject_read", uuid=zaakobject.uuid)
+
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(ZaakObject.objects.count(), 0)
 
 
 @tag("objecttype-overige-definitie")

--- a/src/zrc/api/validators.py
+++ b/src/zrc/api/validators.py
@@ -221,7 +221,13 @@ class EitherFieldRequiredValidator:
 
     requires_context = True
 
-    def __init__(self, fields: Iterable[str], message: str = "", code: str = "", skip_for_updates=False):
+    def __init__(
+        self,
+        fields: Iterable[str],
+        message: str = "",
+        code: str = "",
+        skip_for_updates=False,
+    ):
         self.fields = fields
         self.message = (message or self.default_message) % {"fields": ", ".join(fields)}
         self.code = code or self.default_code

--- a/src/zrc/api/validators.py
+++ b/src/zrc/api/validators.py
@@ -219,12 +219,18 @@ class EitherFieldRequiredValidator:
     default_message = _("One of %(fields)s must be provided")
     default_code = "invalid"
 
-    def __init__(self, fields: Iterable[str], message: str = "", code: str = ""):
+    requires_context = True
+
+    def __init__(self, fields: Iterable[str], message: str = "", code: str = "", skip_for_updates=False):
         self.fields = fields
         self.message = (message or self.default_message) % {"fields": ", ".join(fields)}
         self.code = code or self.default_code
+        self.skip_for_updates = skip_for_updates
 
-    def __call__(self, attrs: dict):
+    def __call__(self, attrs: dict, serializer):
+        if self.skip_for_updates and serializer.instance:
+            return
+
         values = [attrs.get(field, None) for field in self.fields]
         if not any(values):
             raise serializers.ValidationError(self.message, code=self.code)

--- a/src/zrc/api/viewsets.py
+++ b/src/zrc/api/viewsets.py
@@ -380,13 +380,12 @@ class StatusViewSet(
 
 
 class ZaakObjectViewSet(
-    NotificationCreateMixin,
+    NotificationViewSetMixin,
     CheckQueryParamsMixin,
     ListFilterByAuthorizationsMixin,
     AuditTrailCreateMixin,
     ClosedZaakMixin,
-    mixins.CreateModelMixin,
-    viewsets.ReadOnlyModelViewSet,
+    viewsets.ModelViewSet,
 ):
     """
     Opvragen en bewerken van ZAAKOBJECTen.
@@ -395,6 +394,13 @@ class ZaakObjectViewSet(
     Maak een ZAAKOBJECT aan.
 
     Maak een ZAAKOBJECT aan.
+
+    **Er wordt gevalideerd op**
+
+    - Indien de `object` URL opgegeveven is, dan moet deze een geldige response
+      (HTTP 200) geven.
+    - Indien opgegeven, dan wordt `objectIdentificatie` gevalideerd tegen de
+      `objectType` discriminator.
 
     list:
     Alle ZAAKOBJECTen opvragen.
@@ -405,6 +411,30 @@ class ZaakObjectViewSet(
     Een specifiek ZAAKOBJECT opvragen.
 
     Een specifiek ZAAKOBJECT opvragen.
+
+    update:
+    Werk een ZAAKOBJECT in zijn geheel bij.
+
+    **Er wordt gevalideerd op**
+
+    - De attributen `zaak`, `object` en `objectType` mogen niet gewijzigd worden.
+    - Indien opgegeven, dan wordt `objectIdentificatie` gevalideerd tegen de
+      `objectType` discriminator.
+
+    partial_update:
+    Werk een ZAAKOBJECT deels bij.
+
+    **Er wordt gevalideerd op**
+
+    - De attributen `zaak`, `object` en `objectType` mogen niet gewijzigd worden.
+    - Indien opgegeven, dan wordt `objectIdentificatie` gevalideerd tegen de
+      `objectType` discriminator.
+
+    destroy:
+    Verwijder een ZAAKOBJECT.
+
+    Verbreek de relatie tussen een ZAAK en een OBJECT door de ZAAKOBJECT resource te
+    verwijderen.
     """
 
     queryset = ZaakObject.objects.order_by("-pk")
@@ -420,6 +450,11 @@ class ZaakObjectViewSet(
         "create": SCOPE_ZAKEN_CREATE
         | SCOPE_ZAKEN_BIJWERKEN
         | SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN,
+        "update": SCOPE_ZAKEN_BIJWERKEN | SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN,
+        "partial_update": SCOPE_ZAKEN_BIJWERKEN | SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN,
+        "destroy": SCOPE_ZAKEN_BIJWERKEN
+        | SCOPE_ZAKEN_GEFORCEERD_BIJWERKEN
+        | SCOPE_ZAKEN_ALLES_VERWIJDEREN,
     }
     notifications_kanaal = KANAAL_ZAKEN
     audit = AUDIT_ZRC

--- a/src/zrc/tests/test_notifications_send.py
+++ b/src/zrc/tests/test_notifications_send.py
@@ -17,6 +17,7 @@ from zrc.api.scopes import (
 from zrc.datamodel.tests.factories import (
     ResultaatFactory,
     ZaakEigenschapFactory,
+    ZaakObjectFactory,
     ZaakFactory,
 )
 
@@ -146,6 +147,39 @@ class SendNotifTestCase(JWTAuthMixin, APITestCase):
                 "hoofdObject": f"http://testserver{zaak_url}",
                 "resource": "zaakeigenschap",
                 "resourceUrl": f"http://testserver{zaakeigenschap_url}",
+                "actie": "partial_update",
+                "aanmaakdatum": "2012-01-14T00:00:00Z",
+                "kenmerken": {
+                    "bronorganisatie": zaak.bronorganisatie,
+                    "zaaktype": zaak.zaaktype,
+                    "vertrouwelijkheidaanduiding": zaak.vertrouwelijkheidaanduiding,
+                },
+            },
+        )
+
+    @patch("zds_client.Client.from_url")
+    def test_send_notif_update_zaakobject(self, mock_client):
+        """
+        Check if notifications will be send when zaakobject is updated
+        """
+
+        client = mock_client.return_value
+        zaak = ZaakFactory.create(zaaktype=ZAAKTYPE)
+        zaak_url = get_operation_url("zaak_read", uuid=zaak.uuid)
+        zaakobject = ZaakObjectFactory.create(zaak=zaak, relatieomschrijving="old")
+        zaakobject_url = get_operation_url("zaakobject_update", uuid=zaakobject.uuid)
+
+        with capture_on_commit_callbacks(execute=True):
+            response = self.client.patch(zaakobject_url, {"relatieomschrijving": "new"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        client.create.assert_called_once_with(
+            "notificaties",
+            {
+                "kanaal": "zaken",
+                "hoofdObject": f"http://testserver{zaak_url}",
+                "resource": "zaakobject",
+                "resourceUrl": f"http://testserver{zaakobject_url}",
                 "actie": "partial_update",
                 "aanmaakdatum": "2012-01-14T00:00:00Z",
                 "kenmerken": {

--- a/src/zrc/tests/test_notifications_send.py
+++ b/src/zrc/tests/test_notifications_send.py
@@ -17,8 +17,8 @@ from zrc.api.scopes import (
 from zrc.datamodel.tests.factories import (
     ResultaatFactory,
     ZaakEigenschapFactory,
-    ZaakObjectFactory,
     ZaakFactory,
+    ZaakObjectFactory,
 )
 
 from .utils import ZAAK_WRITE_KWARGS


### PR DESCRIPTION
Relates to VNG-Realisatie/gemma-zaken#1727

---

Same problem as with Zaakeigenschappen - it was not possible to update (meta) information or delete a record and replace it with a new one.

- [x] Update API schema
- [x] Update implementation
- [x] Tests