### PR TITLE
#1892 :sparkles: Add extra options for Zaak ordering

### DIFF
--- a/.github/workflows/lint-oas.yml
+++ b/.github/workflows/lint-oas.yml
@@ -19,6 +19,6 @@ jobs:
         with:
           node-version: '12'
       - name: Install spectral
-        run: npm install -g @stoplight/spectral
+        run: npm install -g @stoplight/spectral@5.9.2
       - name: Run OAS linter
         run: spectral lint ./src/openapi.yaml

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -15,6 +15,7 @@ django-choices
 django-cors-middleware
 django-markup
 django-redis
+django-solo>=1.2.0
 
 # API libraries
 djangorestframework

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -38,8 +38,10 @@ django-redis==4.10.0
     # via -r requirements/base.in
 django-rest-framework-condition==0.1.1
     # via vng-api-common
-django-solo==1.1.3
-    # via vng-api-common
+django-solo==1.2.0
+    # via
+    #   -r requirements/base.in
+    #   vng-api-common
 django==2.2.19
     # via
     #   -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -69,7 +69,7 @@ django-rest-framework-condition==0.1.1
     # via
     #   -r requirements/base.txt
     #   vng-api-common
-django-solo==1.1.3
+django-solo==1.2.0
     # via
     #   -r requirements/base.txt
     #   vng-api-common

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -88,7 +88,7 @@ django-rest-framework-condition==0.1.1
     # via
     #   -r requirements/ci.txt
     #   vng-api-common
-django-solo==1.1.3
+django-solo==1.2.0
     # via
     #   -r requirements/ci.txt
     #   vng-api-common

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -3072,10 +3072,19 @@ paths:
           type: string
       - name: ordering
         in: query
-        description: Which field to use when ordering the results.
+        description: Het veld waarop de resultaten geordend worden.
         required: false
         schema:
           type: string
+          enum:
+          - startdatum
+          - -startdatum
+          - einddatum
+          - -einddatum
+          - publicatiedatum
+          - -publicatiedatum
+          - archiefactiedatum
+          - -archiefactiedatum
       - name: page
         in: query
         description: Een pagina binnen de gepagineerde set resultaten.
@@ -7560,9 +7569,37 @@ components:
           minLength: 1
         ordering:
           title: Ordering
-          description: Which field to use when ordering the results.
+          description: 'Het veld waarop de resultaten geordend worden.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `startdatum` - Startdatum
+
+            * `-startdatum` - Startdatum (descending)
+
+            * `einddatum` - Einddatum
+
+            * `-einddatum` - Einddatum (descending)
+
+            * `publicatiedatum` - Publicatiedatum
+
+            * `-publicatiedatum` - Publicatiedatum (descending)
+
+            * `archiefactiedatum` - Archiefactiedatum
+
+            * `-archiefactiedatum` - Archiefactiedatum (descending)'
           type: string
-          minLength: 1
+          enum:
+          - startdatum
+          - -startdatum
+          - einddatum
+          - -einddatum
+          - publicatiedatum
+          - -publicatiedatum
+          - archiefactiedatum
+          - -archiefactiedatum
     Wijzigingen:
       type: object
       properties:

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -3884,9 +3884,19 @@
                     {
                         "name": "ordering",
                         "in": "query",
-                        "description": "Which field to use when ordering the results.",
+                        "description": "Het veld waarop de resultaten geordend worden.",
                         "required": false,
-                        "type": "string"
+                        "type": "string",
+                        "enum": [
+                            "startdatum",
+                            "-startdatum",
+                            "einddatum",
+                            "-einddatum",
+                            "publicatiedatum",
+                            "-publicatiedatum",
+                            "archiefactiedatum",
+                            "-archiefactiedatum"
+                        ]
                     },
                     {
                         "name": "page",
@@ -8971,9 +8981,18 @@
                 },
                 "ordering": {
                     "title": "Ordering",
-                    "description": "Which field to use when ordering the results.",
+                    "description": "Het veld waarop de resultaten geordend worden.\n\nUitleg bij mogelijke waarden:\n\n* `startdatum` - Startdatum\n* `-startdatum` - Startdatum (descending)\n* `einddatum` - Einddatum\n* `-einddatum` - Einddatum (descending)\n* `publicatiedatum` - Publicatiedatum\n* `-publicatiedatum` - Publicatiedatum (descending)\n* `archiefactiedatum` - Archiefactiedatum\n* `-archiefactiedatum` - Archiefactiedatum (descending)",
                     "type": "string",
-                    "minLength": 1
+                    "enum": [
+                        "startdatum",
+                        "-startdatum",
+                        "einddatum",
+                        "-einddatum",
+                        "publicatiedatum",
+                        "-publicatiedatum",
+                        "archiefactiedatum",
+                        "-archiefactiedatum"
+                    ]
                 }
             }
         },

--- a/src/zrc/api/filters.py
+++ b/src/zrc/api/filters.py
@@ -68,6 +68,15 @@ class ZaakFilter(FilterSet):
             ),
         )
     )
+    ordering = filters.OrderingFilter(
+        fields=(
+            "startdatum",
+            "einddatum",
+            "publicatiedatum",
+            "archiefactiedatum",
+        ),
+        help_text="Het veld waarop de resultaten geordend worden.",
+    )
 
     class Meta:
         model = Zaak

--- a/src/zrc/api/tests/test_zaken.py
+++ b/src/zrc/api/tests/test_zaken.py
@@ -547,21 +547,57 @@ class ZakenTests(JWTAuthMixin, APITestCase):
         self.assertEqual(response_gte.data["results"][0]["startdatum"], "2019-03-01")
         self.assertEqual(response_lte.data["results"][0]["startdatum"], "2019-01-01")
 
-    def test_sort_startdatum(self):
-        ZaakFactory.create(zaaktype=ZAAKTYPE, startdatum="2019-01-01")
-        ZaakFactory.create(zaaktype=ZAAKTYPE, startdatum="2019-03-01")
-        ZaakFactory.create(zaaktype=ZAAKTYPE, startdatum="2019-02-01")
-        url = reverse("zaak-list")
+    def test_sort_datum_ascending(self):
+        sorting_params = [
+            "startdatum",
+            "einddatum",
+            "publicatiedatum",
+            "archiefactiedatum",
+        ]
 
-        response = self.client.get(url, {"ordering": "-startdatum"}, **ZAAK_READ_KWARGS)
+        for param in sorting_params:
+            with self.subTest(param=param):
+                Zaak.objects.all().delete()
+                ZaakFactory.create(**{param: "2019-01-01"}, zaaktype=ZAAKTYPE)
+                ZaakFactory.create(**{param: "2019-03-01"}, zaaktype=ZAAKTYPE)
+                ZaakFactory.create(**{param: "2019-02-01"}, zaaktype=ZAAKTYPE)
+                url = reverse("zaak-list")
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+                response = self.client.get(url, {"ordering": param}, **ZAAK_READ_KWARGS)
 
-        data = response.data["results"]
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        self.assertEqual(data[0]["startdatum"], "2019-03-01")
-        self.assertEqual(data[1]["startdatum"], "2019-02-01")
-        self.assertEqual(data[2]["startdatum"], "2019-01-01")
+                data = response.data["results"]
+
+                self.assertEqual(data[0][param], "2019-01-01")
+                self.assertEqual(data[1][param], "2019-02-01")
+                self.assertEqual(data[2][param], "2019-03-01")
+
+    def test_sort_datum_descending(self):
+        sorting_params = [
+            "startdatum",
+            "einddatum",
+            "publicatiedatum",
+            "archiefactiedatum",
+        ]
+
+        for param in sorting_params:
+            with self.subTest(param=param):
+                Zaak.objects.all().delete()
+                ZaakFactory.create(**{param: "2019-01-01"}, zaaktype=ZAAKTYPE)
+                ZaakFactory.create(**{param: "2019-03-01"}, zaaktype=ZAAKTYPE)
+                ZaakFactory.create(**{param: "2019-02-01"}, zaaktype=ZAAKTYPE)
+                url = reverse("zaak-list")
+
+                response = self.client.get(url, {"ordering": param}, **ZAAK_READ_KWARGS)
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                data = response.data["results"]
+
+                self.assertEqual(data[0][param], "2019-01-01")
+                self.assertEqual(data[1][param], "2019-02-01")
+                self.assertEqual(data[2][param], "2019-03-01")
 
     def test_zaak_eigenschappen_as_inline(self):
         zaak1 = ZaakFactory.create(zaaktype=ZAAKTYPE)

--- a/src/zrc/api/viewsets.py
+++ b/src/zrc/api/viewsets.py
@@ -6,7 +6,6 @@ from django.shortcuts import get_object_or_404
 from rest_framework import mixins, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
-from rest_framework.filters import OrderingFilter
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.serializers import ValidationError
 from rest_framework.settings import api_settings
@@ -211,9 +210,8 @@ class ZaakViewSet(
     queryset = Zaak.objects.prefetch_related("deelzaken").order_by("-pk")
     serializer_class = ZaakSerializer
     search_input_serializer_class = ZaakZoekSerializer
-    filter_backends = (Backend, OrderingFilter)
+    filter_backends = (Backend,)
     filterset_class = ZaakFilter
-    ordering_fields = ("startdatum",)
     lookup_field = "uuid"
     pagination_class = PageNumberPagination
 


### PR DESCRIPTION
issue: https://github.com/VNG-Realisatie/gemma-zaken/issues/1892

Changes:
* Add `einddatum`, `publicatiedatum` and `archiefactiedatum` as extra options for Zaak list ordering
* Explicitly document these ordering options in the API spec
* Pin `spectral` dependency in CI to `5.9.2`
* Bump `django-solo` to `1.2.0` to fix CI docker build