### PR TITLE
#1890 :sparkles: Expand parameter for Zaken endpoint

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -3085,6 +3085,18 @@ paths:
           - -publicatiedatum
           - archiefactiedatum
           - -archiefactiedatum
+      - name: expand
+        in: query
+        description: Haal details van inline resources direct op.
+        schema:
+          type: string
+          enum:
+          - status
+          - resultaat
+          - eigenschappen
+          - rollen
+          - zaakobjecten
+          - zaakinformatieobjecten
       - name: page
         in: query
         description: Een pagina binnen de gepagineerde set resultaten.
@@ -3300,6 +3312,18 @@ paths:
         required: false
         schema:
           type: integer
+      - name: expand
+        in: query
+        description: Haal details van inline resources direct op.
+        schema:
+          type: string
+          enum:
+          - status
+          - resultaat
+          - eigenschappen
+          - rollen
+          - zaakobjecten
+          - zaakinformatieobjecten
       - name: Accept-Crs
         in: header
         description: Het gewenste 'Coordinate Reference System' (CRS) van de geometrie
@@ -3397,6 +3421,18 @@ paths:
       summary: Een specifieke ZAAK opvragen.
       description: Een specifieke ZAAK opvragen.
       parameters:
+      - name: expand
+        in: query
+        description: Haal details van inline resources direct op.
+        schema:
+          type: string
+          enum:
+          - status
+          - resultaat
+          - eigenschappen
+          - rollen
+          - zaakobjecten
+          - zaakinformatieobjecten
       - name: Accept-Crs
         in: header
         description: Het gewenste 'Coordinate Reference System' (CRS) van de geometrie
@@ -7621,6 +7657,33 @@ components:
           - -publicatiedatum
           - archiefactiedatum
           - -archiefactiedatum
+        expand:
+          title: Expand
+          description: 'Haal details van inline resources direct op.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `status` - status
+
+            * `resultaat` - resultaat
+
+            * `eigenschappen` - eigenschappen
+
+            * `rollen` - rollen
+
+            * `zaakobjecten` - zaakobjecten
+
+            * `zaakinformatieobjecten` - zaakinformatieobjecten'
+          type: string
+          enum:
+          - status
+          - resultaat
+          - eigenschappen
+          - rollen
+          - zaakobjecten
+          - zaakinformatieobjecten
     Wijzigingen:
       type: object
       properties:

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -7247,6 +7247,13 @@ components:
             format: uri
           readOnly: true
           uniqueItems: true
+        rollen:
+          type: array
+          items:
+            type: string
+            format: uri
+          readOnly: true
+          uniqueItems: true
         status:
           title: Status
           description: Indien geen status bekend is, dan is de waarde 'null'
@@ -7254,6 +7261,20 @@ components:
           format: uri
           readOnly: true
           nullable: true
+        zaakinformatieobjecten:
+          type: array
+          items:
+            type: string
+            format: uri
+          readOnly: true
+          uniqueItems: true
+        zaakobjecten:
+          type: array
+          items:
+            type: string
+            format: uri
+          readOnly: true
+          uniqueItems: true
         kenmerken:
           description: Lijst van kenmerken. Merk op dat refereren naar gerelateerde
             objecten beter kan via `ZaakObject`.

--- a/src/resources.md
+++ b/src/resources.md
@@ -237,7 +237,10 @@ Uitleg bij mogelijke waarden:
 | deelzaken | URL-referenties naar deel ZAAKen. | array | nee | ~~C~~​R​~~U~~​~~D~~ |
 | relevanteAndereZaken | Een lijst van relevante andere zaken. | array | nee | C​R​U​D |
 | eigenschappen |  | array | nee | ~~C~~​R​~~U~~​~~D~~ |
+| rollen |  | array | nee | ~~C~~​R​~~U~~​~~D~~ |
 | status | Indien geen status bekend is, dan is de waarde &#39;null&#39; | string | nee | ~~C~~​R​~~U~~​~~D~~ |
+| zaakinformatieobjecten |  | array | nee | ~~C~~​R​~~U~~​~~D~~ |
+| zaakobjecten |  | array | nee | ~~C~~​R​~~U~~​~~D~~ |
 | kenmerken | Lijst van kenmerken. Merk op dat refereren naar gerelateerde objecten beter kan via `ZaakObject`. | array | nee | C​R​U​D |
 | archiefnominatie | Aanduiding of het zaakdossier blijvend bewaard of na een bepaalde termijn vernietigd moet worden.
 

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -3899,6 +3899,20 @@
                         ]
                     },
                     {
+                        "name": "expand",
+                        "in": "query",
+                        "description": "Haal details van inline resources direct op.",
+                        "type": "string",
+                        "enum": [
+                            "status",
+                            "resultaat",
+                            "eigenschappen",
+                            "rollen",
+                            "zaakobjecten",
+                            "zaakinformatieobjecten"
+                        ]
+                    },
+                    {
                         "name": "page",
                         "in": "query",
                         "description": "Een pagina binnen de gepagineerde set resultaten.",
@@ -4171,6 +4185,20 @@
                         "type": "integer"
                     },
                     {
+                        "name": "expand",
+                        "in": "query",
+                        "description": "Haal details van inline resources direct op.",
+                        "type": "string",
+                        "enum": [
+                            "status",
+                            "resultaat",
+                            "eigenschappen",
+                            "rollen",
+                            "zaakobjecten",
+                            "zaakinformatieobjecten"
+                        ]
+                    },
+                    {
                         "name": "Accept-Crs",
                         "in": "header",
                         "description": "Het gewenste 'Coordinate Reference System' (CRS) van de geometrie in het antwoord (response body). Volgens de GeoJSON spec is WGS84 de default (EPSG:4326 is hetzelfde als WGS84).",
@@ -4288,6 +4316,20 @@
                 "summary": "Een specifieke ZAAK opvragen.",
                 "description": "Een specifieke ZAAK opvragen.",
                 "parameters": [
+                    {
+                        "name": "expand",
+                        "in": "query",
+                        "description": "Haal details van inline resources direct op.",
+                        "type": "string",
+                        "enum": [
+                            "status",
+                            "resultaat",
+                            "eigenschappen",
+                            "rollen",
+                            "zaakobjecten",
+                            "zaakinformatieobjecten"
+                        ]
+                    },
                     {
                         "name": "Accept-Crs",
                         "in": "header",
@@ -9019,6 +9061,19 @@
                         "-publicatiedatum",
                         "archiefactiedatum",
                         "-archiefactiedatum"
+                    ]
+                },
+                "expand": {
+                    "title": "Expand",
+                    "description": "Haal details van inline resources direct op.\n\nUitleg bij mogelijke waarden:\n\n* `status` - status\n* `resultaat` - resultaat\n* `eigenschappen` - eigenschappen\n* `rollen` - rollen\n* `zaakobjecten` - zaakobjecten\n* `zaakinformatieobjecten` - zaakinformatieobjecten",
+                    "type": "string",
+                    "enum": [
+                        "status",
+                        "resultaat",
+                        "eigenschappen",
+                        "rollen",
+                        "zaakobjecten",
+                        "zaakinformatieobjecten"
                     ]
                 }
             }

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -8734,6 +8734,15 @@
                     "readOnly": true,
                     "uniqueItems": true
                 },
+                "rollen": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "uri"
+                    },
+                    "readOnly": true,
+                    "uniqueItems": true
+                },
                 "status": {
                     "title": "Status",
                     "description": "Indien geen status bekend is, dan is de waarde 'null'",
@@ -8741,6 +8750,24 @@
                     "format": "uri",
                     "readOnly": true,
                     "x-nullable": true
+                },
+                "zaakinformatieobjecten": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "uri"
+                    },
+                    "readOnly": true,
+                    "uniqueItems": true
+                },
+                "zaakobjecten": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "uri"
+                    },
+                    "readOnly": true,
+                    "uniqueItems": true
                 },
                 "kenmerken": {
                     "description": "Lijst van kenmerken. Merk op dat refereren naar gerelateerde objecten beter kan via `ZaakObject`.",

--- a/src/zrc/api/filters.py
+++ b/src/zrc/api/filters.py
@@ -15,6 +15,8 @@ from zrc.datamodel.models import (
     ZaakVerzoek,
 )
 
+from .serializers import ZaakSerializer
+
 
 class MaximaleVertrouwelijkheidaanduidingFilter(filters.ChoiceFilter):
     def __init__(self, *args, **kwargs):
@@ -35,6 +37,20 @@ class MaximaleVertrouwelijkheidaanduidingFilter(filters.ChoiceFilter):
         qs = qs.annotate(**{self.field_name: order_expression})
         numeric_value = VertrouwelijkheidsAanduiding.get_choice(value).order
         return super().filter(qs, numeric_value)
+
+
+# TODO move to vng-api-common
+class ExpandFilter(filters.ChoiceFilter):
+    def __init__(self, *args, **kwargs):
+        serializer_class = kwargs.pop("serializer_class")
+        kwargs.setdefault(
+            "choices", [(x, x) for x in serializer_class.Meta.expandable_fields]
+        )
+
+        super().__init__(*args, **kwargs)
+
+    def filter(self, qs, value):
+        return qs
 
 
 class ZaakFilter(FilterSet):
@@ -76,6 +92,10 @@ class ZaakFilter(FilterSet):
             "archiefactiedatum",
         ),
         help_text="Het veld waarop de resultaten geordend worden.",
+    )
+    expand = ExpandFilter(
+        serializer_class=ZaakSerializer,
+        help_text="Haal details van inline resources direct op.",
     )
 
     class Meta:

--- a/src/zrc/api/serializers/core.py
+++ b/src/zrc/api/serializers/core.py
@@ -173,6 +173,13 @@ class ZaakSerializer(
         parent_lookup_kwargs={"zaak_uuid": "zaak__uuid"},
         source="zaakeigenschap_set",
     )
+    rollen = NestedHyperlinkedRelatedField(
+        many=True,
+        read_only=True,
+        lookup_field="uuid",
+        view_name="rol-detail",
+        source="rol_set",
+    )
     status = serializers.HyperlinkedRelatedField(
         source="current_status_uuid",
         read_only=True,
@@ -180,6 +187,20 @@ class ZaakSerializer(
         view_name="status-detail",
         lookup_url_kwarg="uuid",
         help_text=_("Indien geen status bekend is, dan is de waarde 'null'"),
+    )
+    zaakinformatieobjecten = NestedHyperlinkedRelatedField(
+        many=True,
+        read_only=True,
+        lookup_field="uuid",
+        view_name="zaakinformatieobject-detail",
+        source="zaakinformatieobject_set",
+    )
+    zaakobjecten = NestedHyperlinkedRelatedField(
+        many=True,
+        read_only=True,
+        lookup_field="uuid",
+        view_name="zaakobject-detail",
+        source="zaakobject_set",
     )
 
     kenmerken = ZaakKenmerkSerializer(
@@ -269,7 +290,10 @@ class ZaakSerializer(
             "relevante_andere_zaken",
             "eigenschappen",
             # read-only veld, on-the-fly opgevraagd
+            "rollen",
             "status",
+            "zaakinformatieobjecten",
+            "zaakobjecten",
             # Writable inline resource, as opposed to eigenschappen for demo
             # purposes. Eventually, we need to choose one form.
             "kenmerken",

--- a/src/zrc/api/serializers/core.py
+++ b/src/zrc/api/serializers/core.py
@@ -60,6 +60,7 @@ from zrc.datamodel.models.core import ZaakVerzoek
 from zrc.datamodel.utils import BrondatumCalculator
 from zrc.sync.signals import SyncError
 from zrc.utils.exceptions import DetermineProcessEndDateException
+from zrc.utils.serializers import ExpandSerializer
 
 from ..auth import get_auth
 from ..validators import (
@@ -157,341 +158,6 @@ class RelevanteZaakSerializer(serializers.ModelSerializer):
 
         value_display_mapping = add_choice_values_help_text(AardZaakRelatie)
         self.fields["aard_relatie"].help_text += f"\n\n{value_display_mapping}"
-
-
-class ZaakSerializer(
-    NestedGegevensGroepMixin,
-    NestedCreateMixin,
-    NestedUpdateMixin,
-    serializers.HyperlinkedModelSerializer,
-):
-    eigenschappen = NestedHyperlinkedRelatedField(
-        many=True,
-        read_only=True,
-        lookup_field="uuid",
-        view_name="zaakeigenschap-detail",
-        parent_lookup_kwargs={"zaak_uuid": "zaak__uuid"},
-        source="zaakeigenschap_set",
-    )
-    rollen = NestedHyperlinkedRelatedField(
-        many=True,
-        read_only=True,
-        lookup_field="uuid",
-        view_name="rol-detail",
-        source="rol_set",
-    )
-    status = serializers.HyperlinkedRelatedField(
-        source="current_status_uuid",
-        read_only=True,
-        allow_null=True,
-        view_name="status-detail",
-        lookup_url_kwarg="uuid",
-        help_text=_("Indien geen status bekend is, dan is de waarde 'null'"),
-    )
-    zaakinformatieobjecten = NestedHyperlinkedRelatedField(
-        many=True,
-        read_only=True,
-        lookup_field="uuid",
-        view_name="zaakinformatieobject-detail",
-        source="zaakinformatieobject_set",
-    )
-    zaakobjecten = NestedHyperlinkedRelatedField(
-        many=True,
-        read_only=True,
-        lookup_field="uuid",
-        view_name="zaakobject-detail",
-        source="zaakobject_set",
-    )
-
-    kenmerken = ZaakKenmerkSerializer(
-        source="zaakkenmerk_set",
-        many=True,
-        required=False,
-        help_text="Lijst van kenmerken. Merk op dat refereren naar gerelateerde objecten "
-        "beter kan via `ZaakObject`.",
-    )
-
-    betalingsindicatie_weergave = serializers.CharField(
-        source="get_betalingsindicatie_display",
-        read_only=True,
-        help_text=_("Uitleg bij `betalingsindicatie`."),
-    )
-
-    verlenging = VerlengingSerializer(
-        required=False,
-        allow_null=True,
-        help_text=_(
-            "Gegevens omtrent het verlengen van de doorlooptijd van de behandeling van de ZAAK"
-        ),
-    )
-
-    opschorting = OpschortingSerializer(
-        required=False,
-        allow_null=True,
-        help_text=_(
-            "Gegevens omtrent het tijdelijk opschorten van de behandeling van de ZAAK"
-        ),
-    )
-
-    deelzaken = serializers.HyperlinkedRelatedField(
-        read_only=True,
-        many=True,
-        view_name="zaak-detail",
-        lookup_url_kwarg="uuid",
-        lookup_field="uuid",
-        help_text=_("URL-referenties naar deel ZAAKen."),
-    )
-
-    resultaat = serializers.HyperlinkedRelatedField(
-        read_only=True,
-        allow_null=True,
-        view_name="resultaat-detail",
-        lookup_url_kwarg="uuid",
-        lookup_field="uuid",
-        help_text=_(
-            "URL-referentie naar het RESULTAAT. Indien geen resultaat bekend is, dan is de waarde 'null'"
-        ),
-    )
-
-    relevante_andere_zaken = RelevanteZaakSerializer(
-        many=True, required=False, help_text=_("Een lijst van relevante andere zaken.")
-    )
-
-    class Meta:
-        model = Zaak
-        fields = (
-            "url",
-            "uuid",
-            "identificatie",
-            "bronorganisatie",
-            "omschrijving",
-            "toelichting",
-            "zaaktype",
-            "registratiedatum",
-            "verantwoordelijke_organisatie",
-            "startdatum",
-            "einddatum",
-            "einddatum_gepland",
-            "uiterlijke_einddatum_afdoening",
-            "publicatiedatum",
-            "communicatiekanaal",
-            # TODO: add shape validator once we know the shape
-            "producten_of_diensten",
-            "vertrouwelijkheidaanduiding",
-            "betalingsindicatie",
-            "betalingsindicatie_weergave",
-            "laatste_betaaldatum",
-            "zaakgeometrie",
-            "verlenging",
-            "opschorting",
-            "selectielijstklasse",
-            "hoofdzaak",
-            "deelzaken",
-            "relevante_andere_zaken",
-            "eigenschappen",
-            # read-only veld, on-the-fly opgevraagd
-            "rollen",
-            "status",
-            "zaakinformatieobjecten",
-            "zaakobjecten",
-            # Writable inline resource, as opposed to eigenschappen for demo
-            # purposes. Eventually, we need to choose one form.
-            "kenmerken",
-            # Archiving
-            "archiefnominatie",
-            "archiefstatus",
-            "archiefactiedatum",
-            "resultaat",
-            "opdrachtgevende_organisatie",
-        )
-        extra_kwargs = {
-            "url": {"lookup_field": "uuid"},
-            "uuid": {"read_only": True},
-            "zaakgeometrie": {
-                "help_text": "Punt, lijn of (multi-)vlak geometrie-informatie, in GeoJSON."
-            },
-            "identificatie": {"validators": [IsImmutableValidator()]},
-            "zaaktype": {
-                # TODO: does order matter here with the default validators?
-                "validators": [
-                    IsImmutableValidator(),
-                    PublishValidator(
-                        "ZaakType", settings.ZTC_API_SPEC, get_auth=get_auth
-                    ),
-                ]
-            },
-            "einddatum": {"read_only": True, "allow_null": True},
-            "communicatiekanaal": {
-                "validators": [
-                    ResourceValidator(
-                        "CommunicatieKanaal", settings.REFERENTIELIJSTEN_API_SPEC
-                    )
-                ]
-            },
-            "vertrouwelijkheidaanduiding": {
-                "required": False,
-                "help_text": _(
-                    "Aanduiding van de mate waarin het zaakdossier van de "
-                    "ZAAK voor de openbaarheid bestemd is. Optioneel - indien "
-                    "geen waarde gekozen wordt, dan wordt de waarde van het "
-                    "ZAAKTYPE overgenomen. Dit betekent dat de API _altijd_ een "
-                    "waarde teruggeeft."
-                ),
-            },
-            "selectielijstklasse": {
-                "validators": [
-                    ResourceValidator(
-                        "Resultaat",
-                        settings.REFERENTIELIJSTEN_API_SPEC,
-                        get_auth=get_auth,
-                    )
-                ]
-            },
-            "hoofdzaak": {
-                "lookup_field": "uuid",
-                "queryset": Zaak.objects.all(),
-                "validators": [NotSelfValidator(), HoofdzaakValidator()],
-            },
-            "laatste_betaaldatum": {"validators": [UntilNowValidator()]},
-        }
-        # Replace a default "unique together" constraint.
-        validators = [UniekeIdentificatieValidator(), HoofdZaaktypeRelationValidator()]
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        value_display_mapping = add_choice_values_help_text(BetalingsIndicatie)
-        self.fields["betalingsindicatie"].help_text += f"\n\n{value_display_mapping}"
-
-        value_display_mapping = add_choice_values_help_text(Archiefstatus)
-        self.fields["archiefstatus"].help_text += f"\n\n{value_display_mapping}"
-
-        value_display_mapping = add_choice_values_help_text(Archiefnominatie)
-        self.fields["archiefnominatie"].help_text += f"\n\n{value_display_mapping}"
-
-    def _get_zaaktype(self, zaaktype_url: str) -> dict:
-        if not hasattr(self, "_zaaktype"):
-            # dynamic so that it can be mocked in tests easily
-            Client = import_string(settings.ZDS_CLIENT_CLASS)
-            client = Client.from_url(zaaktype_url)
-            client.auth = APICredential.get_auth(
-                zaaktype_url, scopes=["zds.scopes.zaaktypes.lezen"]
-            )
-            self._zaaktype = client.request(zaaktype_url, "zaaktype")
-        return self._zaaktype
-
-    def _get_information_objects(self) -> list:
-        if not hasattr(self, "_information_objects"):
-            self._information_objects = []
-
-            if self.instance:
-                Client = import_string(settings.ZDS_CLIENT_CLASS)
-
-                zios = self.instance.zaakinformatieobject_set.all()
-                for zio in zios:
-                    io_url = zio.informatieobject
-                    client = Client.from_url(io_url)
-                    client.auth = APICredential.get_auth(
-                        io_url, scopes=["scopes.documenten.lezen"]
-                    )
-                    informatieobject = client.request(
-                        io_url, "enkelvoudiginformatieobject"
-                    )
-                    self._information_objects.append(informatieobject)
-
-        return self._information_objects
-
-    def validate(self, attrs):
-        super().validate(attrs)
-
-        default_betalingsindicatie = (
-            self.instance.betalingsindicatie if self.instance else None
-        )
-        betalingsindicatie = attrs.get("betalingsindicatie", default_betalingsindicatie)
-        if betalingsindicatie == BetalingsIndicatie.nvt and attrs.get(
-            "laatste_betaaldatum"
-        ):
-            raise serializers.ValidationError(
-                {
-                    "laatste_betaaldatum": _(
-                        'Laatste betaaldatum kan niet gezet worden als de betalingsindicatie "nvt" is'
-                    )
-                },
-                code="betaling-nvt",
-            )
-
-        # check that productenOfDiensten are part of the ones on the zaaktype
-        default_zaaktype = self.instance.zaaktype if self.instance else None
-        zaaktype = attrs.get("zaaktype", default_zaaktype)
-        assert zaaktype, "Should not have passed validation - a zaaktype is needed"
-        producten_of_diensten = attrs.get("producten_of_diensten")
-        if producten_of_diensten:
-            zaaktype = self._get_zaaktype(zaaktype)
-            if not set(producten_of_diensten).issubset(
-                set(zaaktype["productenOfDiensten"])
-            ):
-                raise serializers.ValidationError(
-                    {
-                        "producten_of_diensten": _(
-                            "Niet alle producten/diensten komen voor in "
-                            "de producten/diensten op het zaaktype"
-                        )
-                    },
-                    code="invalid-products-services",
-                )
-
-        # Archiving
-        default_archiefstatus = (
-            self.instance.archiefstatus
-            if self.instance
-            else Archiefstatus.nog_te_archiveren
-        )
-        archiefstatus = (
-            attrs.get("archiefstatus", default_archiefstatus)
-            != Archiefstatus.nog_te_archiveren
-        )
-        if archiefstatus:
-            ios = self._get_information_objects()
-            for io in ios:
-                if io["status"] != "gearchiveerd":
-                    raise serializers.ValidationError(
-                        {
-                            "archiefstatus",
-                            _(
-                                "Er zijn gerelateerde informatieobjecten waarvan de `status` nog niet gelijk is aan "
-                                "`gearchiveerd`. Dit is een voorwaarde voor het zetten van de `archiefstatus` op een andere "
-                                "waarde dan `nog_te_archiveren`."
-                            ),
-                        },
-                        code="documents-not-archived",
-                    )
-
-            for attr in ["archiefnominatie", "archiefactiedatum"]:
-                if not attrs.get(
-                    attr, getattr(self.instance, attr) if self.instance else None
-                ):
-                    raise serializers.ValidationError(
-                        {
-                            attr: _(
-                                "Moet van een waarde voorzien zijn als de 'Archiefstatus' een waarde heeft anders dan "
-                                "'nog_te_archiveren'."
-                            )
-                        },
-                        code=f"{attr}-not-set",
-                    )
-        # End archiving
-
-        return attrs
-
-    def create(self, validated_data: dict):
-        # set the derived value from ZTC
-        if "vertrouwelijkheidaanduiding" not in validated_data:
-            zaaktype = self._get_zaaktype(validated_data["zaaktype"])
-            validated_data["vertrouwelijkheidaanduiding"] = zaaktype[
-                "vertrouwelijkheidaanduiding"
-            ]
-
-        return super().create(validated_data)
 
 
 class GeoWithinSerializer(serializers.Serializer):
@@ -1202,3 +868,393 @@ class ZaakVerzoekSerializer(serializers.HyperlinkedModelSerializer):
             raise serializers.ValidationError(
                 {api_settings.NON_FIELD_ERRORS_KEY: sync_error.args[0]}
             ) from sync_error
+
+
+class ZaakSerializer(
+    NestedGegevensGroepMixin,
+    NestedCreateMixin,
+    NestedUpdateMixin,
+    serializers.HyperlinkedModelSerializer,
+):
+    eigenschappen = ExpandSerializer(
+        name="eigenschappen",
+        source="zaakeigenschap_set",
+        default_serializer=NestedHyperlinkedRelatedField,
+        expanded_serializer=ZaakEigenschapSerializer,
+        many=True,
+        read_only=True,
+        common_kwargs={
+            "read_only": True,
+        },
+        default_serializer_kwargs={
+            "parent_lookup_kwargs": {"zaak_uuid": "zaak__uuid"},
+            "lookup_field": "uuid",
+            "view_name": "zaakeigenschap-detail",
+        },
+    )
+    rollen = ExpandSerializer(
+        name="rollen",
+        source="rol_set",
+        default_serializer=NestedHyperlinkedRelatedField,
+        expanded_serializer=RolSerializer,
+        many=True,
+        read_only=True,
+        common_kwargs={
+            "read_only": True,
+        },
+        default_serializer_kwargs={
+            "lookup_field": "uuid",
+            "view_name": "rol-detail",
+        },
+    )
+    status = ExpandSerializer(
+        name="status",
+        source="current_status",
+        default_serializer=serializers.HyperlinkedRelatedField,
+        expanded_serializer=StatusSerializer,
+        read_only=True,
+        common_kwargs={
+            "allow_null": True,
+            "read_only": True,
+        },
+        default_serializer_kwargs={
+            "lookup_field": "uuid",
+            "view_name": "status-detail",
+        },
+        help_text=_("Indien geen status bekend is, dan is de waarde 'null'"),
+    )
+    zaakinformatieobjecten = ExpandSerializer(
+        name="zaakinformatieobjecten",
+        source="zaakinformatieobject_set",
+        default_serializer=NestedHyperlinkedRelatedField,
+        expanded_serializer=ZaakInformatieObjectSerializer,
+        many=True,
+        read_only=True,
+        common_kwargs={
+            "read_only": True,
+        },
+        default_serializer_kwargs={
+            "lookup_field": "uuid",
+            "view_name": "zaakinformatieobject-detail",
+        },
+    )
+    zaakobjecten = ExpandSerializer(
+        name="zaakobjecten",
+        source="zaakobject_set",
+        default_serializer=NestedHyperlinkedRelatedField,
+        expanded_serializer=ZaakObjectSerializer,
+        many=True,
+        read_only=True,
+        common_kwargs={
+            "read_only": True,
+        },
+        default_serializer_kwargs={
+            "lookup_field": "uuid",
+            "view_name": "zaakobject-detail",
+        },
+    )
+
+    kenmerken = ZaakKenmerkSerializer(
+        source="zaakkenmerk_set",
+        many=True,
+        required=False,
+        help_text="Lijst van kenmerken. Merk op dat refereren naar gerelateerde objecten "
+        "beter kan via `ZaakObject`.",
+    )
+
+    betalingsindicatie_weergave = serializers.CharField(
+        source="get_betalingsindicatie_display",
+        read_only=True,
+        help_text=_("Uitleg bij `betalingsindicatie`."),
+    )
+
+    verlenging = VerlengingSerializer(
+        required=False,
+        allow_null=True,
+        help_text=_(
+            "Gegevens omtrent het verlengen van de doorlooptijd van de behandeling van de ZAAK"
+        ),
+    )
+
+    opschorting = OpschortingSerializer(
+        required=False,
+        allow_null=True,
+        help_text=_(
+            "Gegevens omtrent het tijdelijk opschorten van de behandeling van de ZAAK"
+        ),
+    )
+
+    deelzaken = serializers.HyperlinkedRelatedField(
+        read_only=True,
+        many=True,
+        view_name="zaak-detail",
+        lookup_url_kwarg="uuid",
+        lookup_field="uuid",
+        help_text=_("URL-referenties naar deel ZAAKen."),
+    )
+
+    resultaat = ExpandSerializer(
+        name="resultaat",
+        default_serializer=serializers.HyperlinkedRelatedField,
+        expanded_serializer=ResultaatSerializer,
+        read_only=True,
+        common_kwargs={
+            "allow_null": True,
+            "read_only": True,
+        },
+        default_serializer_kwargs={
+            "lookup_field": "uuid",
+            "view_name": "resultaat-detail",
+        },
+        help_text=_(
+            "URL-referentie naar het RESULTAAT. Indien geen resultaat bekend is, dan is de waarde 'null'"
+        ),
+    )
+
+    relevante_andere_zaken = RelevanteZaakSerializer(
+        many=True, required=False, help_text=_("Een lijst van relevante andere zaken.")
+    )
+
+    class Meta:
+        model = Zaak
+        fields = (
+            "url",
+            "uuid",
+            "identificatie",
+            "bronorganisatie",
+            "omschrijving",
+            "toelichting",
+            "zaaktype",
+            "registratiedatum",
+            "verantwoordelijke_organisatie",
+            "startdatum",
+            "einddatum",
+            "einddatum_gepland",
+            "uiterlijke_einddatum_afdoening",
+            "publicatiedatum",
+            "communicatiekanaal",
+            # TODO: add shape validator once we know the shape
+            "producten_of_diensten",
+            "vertrouwelijkheidaanduiding",
+            "betalingsindicatie",
+            "betalingsindicatie_weergave",
+            "laatste_betaaldatum",
+            "zaakgeometrie",
+            "verlenging",
+            "opschorting",
+            "selectielijstklasse",
+            "hoofdzaak",
+            "deelzaken",
+            "relevante_andere_zaken",
+            "eigenschappen",
+            # read-only veld, on-the-fly opgevraagd
+            "rollen",
+            "status",
+            "zaakinformatieobjecten",
+            "zaakobjecten",
+            # Writable inline resource, as opposed to eigenschappen for demo
+            # purposes. Eventually, we need to choose one form.
+            "kenmerken",
+            # Archiving
+            "archiefnominatie",
+            "archiefstatus",
+            "archiefactiedatum",
+            "resultaat",
+            "opdrachtgevende_organisatie",
+        )
+        extra_kwargs = {
+            "url": {"lookup_field": "uuid"},
+            "uuid": {"read_only": True},
+            "zaakgeometrie": {
+                "help_text": "Punt, lijn of (multi-)vlak geometrie-informatie, in GeoJSON."
+            },
+            "identificatie": {"validators": [IsImmutableValidator()]},
+            "zaaktype": {
+                # TODO: does order matter here with the default validators?
+                "validators": [
+                    IsImmutableValidator(),
+                    PublishValidator(
+                        "ZaakType", settings.ZTC_API_SPEC, get_auth=get_auth
+                    ),
+                ]
+            },
+            "einddatum": {"read_only": True, "allow_null": True},
+            "communicatiekanaal": {
+                "validators": [
+                    ResourceValidator(
+                        "CommunicatieKanaal", settings.REFERENTIELIJSTEN_API_SPEC
+                    )
+                ]
+            },
+            "vertrouwelijkheidaanduiding": {
+                "required": False,
+                "help_text": _(
+                    "Aanduiding van de mate waarin het zaakdossier van de "
+                    "ZAAK voor de openbaarheid bestemd is. Optioneel - indien "
+                    "geen waarde gekozen wordt, dan wordt de waarde van het "
+                    "ZAAKTYPE overgenomen. Dit betekent dat de API _altijd_ een "
+                    "waarde teruggeeft."
+                ),
+            },
+            "selectielijstklasse": {
+                "validators": [
+                    ResourceValidator(
+                        "Resultaat",
+                        settings.REFERENTIELIJSTEN_API_SPEC,
+                        get_auth=get_auth,
+                    )
+                ]
+            },
+            "hoofdzaak": {
+                "lookup_field": "uuid",
+                "queryset": Zaak.objects.all(),
+                "validators": [NotSelfValidator(), HoofdzaakValidator()],
+            },
+            "laatste_betaaldatum": {"validators": [UntilNowValidator()]},
+        }
+        # Replace a default "unique together" constraint.
+        validators = [UniekeIdentificatieValidator(), HoofdZaaktypeRelationValidator()]
+        expandable_fields = [
+            "status",
+            "resultaat",
+            "eigenschappen",
+            "rollen",
+            "zaakobjecten",
+            "zaakinformatieobjecten",
+        ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        value_display_mapping = add_choice_values_help_text(BetalingsIndicatie)
+        self.fields["betalingsindicatie"].help_text += f"\n\n{value_display_mapping}"
+
+        value_display_mapping = add_choice_values_help_text(Archiefstatus)
+        self.fields["archiefstatus"].help_text += f"\n\n{value_display_mapping}"
+
+        value_display_mapping = add_choice_values_help_text(Archiefnominatie)
+        self.fields["archiefnominatie"].help_text += f"\n\n{value_display_mapping}"
+
+    def _get_zaaktype(self, zaaktype_url: str) -> dict:
+        if not hasattr(self, "_zaaktype"):
+            # dynamic so that it can be mocked in tests easily
+            Client = import_string(settings.ZDS_CLIENT_CLASS)
+            client = Client.from_url(zaaktype_url)
+            client.auth = APICredential.get_auth(
+                zaaktype_url, scopes=["zds.scopes.zaaktypes.lezen"]
+            )
+            self._zaaktype = client.request(zaaktype_url, "zaaktype")
+        return self._zaaktype
+
+    def _get_information_objects(self) -> list:
+        if not hasattr(self, "_information_objects"):
+            self._information_objects = []
+
+            if self.instance:
+                Client = import_string(settings.ZDS_CLIENT_CLASS)
+
+                zios = self.instance.zaakinformatieobject_set.all()
+                for zio in zios:
+                    io_url = zio.informatieobject
+                    client = Client.from_url(io_url)
+                    client.auth = APICredential.get_auth(
+                        io_url, scopes=["scopes.documenten.lezen"]
+                    )
+                    informatieobject = client.request(
+                        io_url, "enkelvoudiginformatieobject"
+                    )
+                    self._information_objects.append(informatieobject)
+
+        return self._information_objects
+
+    def validate(self, attrs):
+        super().validate(attrs)
+
+        default_betalingsindicatie = (
+            self.instance.betalingsindicatie if self.instance else None
+        )
+        betalingsindicatie = attrs.get("betalingsindicatie", default_betalingsindicatie)
+        if betalingsindicatie == BetalingsIndicatie.nvt and attrs.get(
+            "laatste_betaaldatum"
+        ):
+            raise serializers.ValidationError(
+                {
+                    "laatste_betaaldatum": _(
+                        'Laatste betaaldatum kan niet gezet worden als de betalingsindicatie "nvt" is'
+                    )
+                },
+                code="betaling-nvt",
+            )
+
+        # check that productenOfDiensten are part of the ones on the zaaktype
+        default_zaaktype = self.instance.zaaktype if self.instance else None
+        zaaktype = attrs.get("zaaktype", default_zaaktype)
+        assert zaaktype, "Should not have passed validation - a zaaktype is needed"
+        producten_of_diensten = attrs.get("producten_of_diensten")
+        if producten_of_diensten:
+            zaaktype = self._get_zaaktype(zaaktype)
+            if not set(producten_of_diensten).issubset(
+                set(zaaktype["productenOfDiensten"])
+            ):
+                raise serializers.ValidationError(
+                    {
+                        "producten_of_diensten": _(
+                            "Niet alle producten/diensten komen voor in "
+                            "de producten/diensten op het zaaktype"
+                        )
+                    },
+                    code="invalid-products-services",
+                )
+
+        # Archiving
+        default_archiefstatus = (
+            self.instance.archiefstatus
+            if self.instance
+            else Archiefstatus.nog_te_archiveren
+        )
+        archiefstatus = (
+            attrs.get("archiefstatus", default_archiefstatus)
+            != Archiefstatus.nog_te_archiveren
+        )
+        if archiefstatus:
+            ios = self._get_information_objects()
+            for io in ios:
+                if io["status"] != "gearchiveerd":
+                    raise serializers.ValidationError(
+                        {
+                            "archiefstatus",
+                            _(
+                                "Er zijn gerelateerde informatieobjecten waarvan de `status` nog niet gelijk is aan "
+                                "`gearchiveerd`. Dit is een voorwaarde voor het zetten van de `archiefstatus` op een andere "
+                                "waarde dan `nog_te_archiveren`."
+                            ),
+                        },
+                        code="documents-not-archived",
+                    )
+
+            for attr in ["archiefnominatie", "archiefactiedatum"]:
+                if not attrs.get(
+                    attr, getattr(self.instance, attr) if self.instance else None
+                ):
+                    raise serializers.ValidationError(
+                        {
+                            attr: _(
+                                "Moet van een waarde voorzien zijn als de 'Archiefstatus' een waarde heeft anders dan "
+                                "'nog_te_archiveren'."
+                            )
+                        },
+                        code=f"{attr}-not-set",
+                    )
+        # End archiving
+
+        return attrs
+
+    def create(self, validated_data: dict):
+        # set the derived value from ZTC
+        if "vertrouwelijkheidaanduiding" not in validated_data:
+            zaaktype = self._get_zaaktype(validated_data["zaaktype"])
+            validated_data["vertrouwelijkheidaanduiding"] = zaaktype[
+                "vertrouwelijkheidaanduiding"
+            ]
+
+        return super().create(validated_data)

--- a/src/zrc/api/tests/test_zaken.py
+++ b/src/zrc/api/tests/test_zaken.py
@@ -12,6 +12,7 @@ from rest_framework.test import APITestCase
 from vng_api_common.constants import (
     Archiefnominatie,
     BrondatumArchiefprocedureAfleidingswijze,
+    ComponentTypes,
     RolOmschrijving,
     RolTypes,
     VertrouwelijkheidsAanduiding,
@@ -32,6 +33,7 @@ from zrc.datamodel.models import (
     Zaak,
 )
 from zrc.datamodel.tests.factories import (
+    ResultaatFactory,
     RolFactory,
     StatusFactory,
     ZaakBesluitFactory,
@@ -1130,3 +1132,246 @@ class ZakenWerkVoorraadTests(JWTAuthMixin, APITestCase):
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertEqual(response.data["count"], 1)
+
+
+class ZakenExpandTests(ZaakInformatieObjectSyncMixin, JWTAuthMixin, APITestCase):
+
+    scopes = [SCOPE_ZAKEN_ALLES_LEZEN]
+    zaaktype = ZAAKTYPE
+    component = ComponentTypes.zrc
+    maxDiff = None
+
+    def test_list_expand(self):
+        zaak = ZaakFactory.create(zaaktype=ZAAKTYPE)
+        zaak_url = reverse(zaak)
+
+        # Create related resources
+        RolFactory.create_batch(2, zaak=zaak)
+        ZaakObjectFactory.create_batch(2, zaak=zaak)
+        ZaakInformatieObjectFactory.create_batch(2, zaak=zaak)
+        ZaakEigenschapFactory.create_batch(2, zaak=zaak)
+        zaak_status = StatusFactory.create(zaak=zaak)
+        resultaat = ResultaatFactory.create(zaak=zaak)
+
+        # Create unrelated resources
+        RolFactory.create_batch(2)
+        ZaakObjectFactory.create_batch(2)
+        ZaakInformatieObjectFactory.create_batch(2)
+        ZaakEigenschapFactory.create_batch(2)
+        StatusFactory.create_batch(2)
+        ResultaatFactory.create_batch(2)
+
+        url = reverse(Zaak)
+
+        for resource in [
+            "status",
+            "resultaat",
+            "eigenschappen",
+            "rollen",
+            "zaakobjecten",
+            "zaakinformatieobjecten",
+        ]:
+            with self.subTest(resource=resource):
+                response = self.client.get(
+                    url, {"expand": resource}, **ZAAK_READ_KWARGS
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertEqual(response.data["count"], 1)
+
+                inline_resources = response.data["results"][0][resource]
+
+                if resource == "status":
+                    self.assertEqual(
+                        inline_resources["zaak"], f"http://testserver{zaak_url}"
+                    )
+                    self.assertEqual(inline_resources["uuid"], str(zaak_status.uuid))
+                elif resource == "resultaat":
+                    self.assertEqual(
+                        inline_resources["zaak"], f"http://testserver{zaak_url}"
+                    )
+                    self.assertEqual(inline_resources["uuid"], str(resultaat.uuid))
+                else:
+                    self.assertEqual(len(inline_resources), 2)
+                    self.assertEqual(
+                        *[r["zaak"] for r in inline_resources],
+                        f"http://testserver{zaak_url}",
+                    )
+
+    def test_list_expand_some(self):
+        zaak = ZaakFactory.create(startdatum="2019-01-01", zaaktype=ZAAKTYPE)
+        zaak_url = reverse(zaak)
+        RolFactory.create_batch(2, zaak=zaak)
+        ZaakObjectFactory.create_batch(2, zaak=zaak)
+        ZaakInformatieObjectFactory.create_batch(2, zaak=zaak)
+
+        # Create unrelated resources
+        RolFactory.create_batch(2)
+        ZaakObjectFactory.create_batch(2)
+        ZaakInformatieObjectFactory.create_batch(2)
+
+        url = reverse("zaak-list")
+
+        response = self.client.get(
+            url,
+            {"expand": ["zaakobjecten", "zaakinformatieobjecten"]},
+            **ZAAK_READ_KWARGS,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+        zaakobjecten = response.data["results"][0]["zaakobjecten"]
+        self.assertEqual(len(zaakobjecten), 2)
+        self.assertEqual(
+            *[r["zaak"] for r in zaakobjecten],
+            f"http://testserver{zaak_url}",
+        )
+
+        zaakinformatieobjecten = response.data["results"][0]["zaakinformatieobjecten"]
+        self.assertEqual(len(zaakinformatieobjecten), 2)
+        self.assertEqual(
+            *[r["zaak"] for r in zaakinformatieobjecten],
+            f"http://testserver{zaak_url}",
+        )
+
+        # Rollen should not be expanded
+        rollen = response.data["results"][0]["rollen"]
+        self.assertEqual(len(rollen), 2)
+        self.assertTrue(*[isinstance(r, str) for r in rollen])
+
+    def test_list_expand_all(self):
+        zaak = ZaakFactory.create(startdatum="2019-01-01", zaaktype=ZAAKTYPE)
+        zaak_url = reverse(zaak)
+
+        # Create related resources
+        RolFactory.create_batch(2, zaak=zaak)
+        ZaakObjectFactory.create_batch(2, zaak=zaak)
+        ZaakInformatieObjectFactory.create_batch(2, zaak=zaak)
+        ZaakEigenschapFactory.create_batch(2, zaak=zaak)
+        zaak_status = StatusFactory.create(zaak=zaak)
+        resultaat = ResultaatFactory.create(zaak=zaak)
+
+        # Create unrelated resources
+        RolFactory.create_batch(2)
+        ZaakObjectFactory.create_batch(2)
+        ZaakInformatieObjectFactory.create_batch(2)
+        ZaakEigenschapFactory.create_batch(2)
+        StatusFactory.create_batch(2)
+        ResultaatFactory.create_batch(2)
+
+        url = reverse(Zaak)
+
+        resources = [
+            "status",
+            "resultaat",
+            "eigenschappen",
+            "rollen",
+            "zaakobjecten",
+            "zaakinformatieobjecten",
+        ]
+
+        response = self.client.get(url, {"expand": resources}, **ZAAK_READ_KWARGS)
+
+        for resource in resources:
+            with self.subTest(resource=resource):
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertEqual(response.data["count"], 1)
+
+                inline_resources = response.data["results"][0][resource]
+
+                if resource == "status":
+                    self.assertEqual(
+                        inline_resources["zaak"], f"http://testserver{zaak_url}"
+                    )
+                    self.assertEqual(inline_resources["uuid"], str(zaak_status.uuid))
+                elif resource == "resultaat":
+                    self.assertEqual(
+                        inline_resources["zaak"], f"http://testserver{zaak_url}"
+                    )
+                    self.assertEqual(inline_resources["uuid"], str(resultaat.uuid))
+                else:
+                    self.assertEqual(len(inline_resources), 2)
+                    self.assertEqual(
+                        *[r["zaak"] for r in inline_resources],
+                        f"http://testserver{zaak_url}",
+                    )
+
+    def test_detail_expand(self):
+        zaak = ZaakFactory.create(startdatum="2019-01-01", zaaktype=ZAAKTYPE)
+        zaak_url = reverse(zaak)
+
+        # Create related resources
+        RolFactory.create_batch(2, zaak=zaak)
+        ZaakObjectFactory.create_batch(2, zaak=zaak)
+        ZaakInformatieObjectFactory.create_batch(2, zaak=zaak)
+        ZaakEigenschapFactory.create_batch(2, zaak=zaak)
+        zaak_status = StatusFactory.create(zaak=zaak)
+        resultaat = ResultaatFactory.create(zaak=zaak)
+
+        # Create unrelated resources
+        RolFactory.create_batch(2)
+        ZaakObjectFactory.create_batch(2)
+        ZaakInformatieObjectFactory.create_batch(2)
+        ZaakEigenschapFactory.create_batch(2)
+        StatusFactory.create_batch(2)
+        ResultaatFactory.create_batch(2)
+
+        url = reverse(zaak)
+
+        for resource in [
+            "status",
+            "resultaat",
+            "eigenschappen",
+            "rollen",
+            "zaakobjecten",
+            "zaakinformatieobjecten",
+        ]:
+            with self.subTest(resource=resource):
+                response = self.client.get(
+                    url, {"expand": resource}, **ZAAK_READ_KWARGS
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                inline_resources = response.data[resource]
+
+                if resource == "status":
+                    self.assertEqual(
+                        inline_resources["zaak"], f"http://testserver{zaak_url}"
+                    )
+                    self.assertEqual(inline_resources["uuid"], str(zaak_status.uuid))
+                elif resource == "resultaat":
+                    self.assertEqual(
+                        inline_resources["zaak"], f"http://testserver{zaak_url}"
+                    )
+                    self.assertEqual(inline_resources["uuid"], str(resultaat.uuid))
+                else:
+                    self.assertEqual(len(inline_resources), 2)
+                    self.assertEqual(
+                        *[r["zaak"] for r in inline_resources],
+                        f"http://testserver{zaak_url}",
+                    )
+
+    def test_list_expand_invalid_parameter(self):
+        ZaakFactory.create(startdatum="2019-01-01", zaaktype=ZAAKTYPE)
+
+        url = reverse(Zaak)
+
+        response = self.client.get(url, {"expand": "foo"}, **ZAAK_READ_KWARGS)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "expand")
+        self.assertEqual(error["code"], "invalid_choice")
+
+    def test_detail_expand_invalid_parameter(self):
+        zaak = ZaakFactory.create(startdatum="2019-01-01", zaaktype=ZAAKTYPE)
+
+        url = reverse(zaak)
+
+        response = self.client.get(url, {"expand": "foo"}, **ZAAK_READ_KWARGS)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        error = get_validation_errors(response, "expand")
+        self.assertEqual(error["code"], "invalid_choice")

--- a/src/zrc/api/viewsets.py
+++ b/src/zrc/api/viewsets.py
@@ -3,6 +3,8 @@ import logging
 from django.core.cache import caches
 from django.shortcuts import get_object_or_404
 
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import mixins, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
@@ -90,6 +92,15 @@ from .serializers import (
 from .validators import ZaakBesluitValidator
 
 logger = logging.getLogger(__name__)
+
+
+EXPAND_PARAMETER = openapi.Parameter(
+    "expand",
+    openapi.IN_QUERY,
+    description="Haal details van inline resources direct op.",
+    type=openapi.TYPE_STRING,
+    enum=ZaakSerializer.Meta.expandable_fields,
+)
 
 
 @conditional_retrieve()
@@ -233,6 +244,15 @@ class ZaakViewSet(
     notifications_kanaal = KANAAL_ZAKEN
     audit = AUDIT_ZRC
 
+    @swagger_auto_schema(manual_parameters=[EXPAND_PARAMETER])
+    def retrieve(self, request, *args, **kwargs):
+        return super().retrieve(request, *args, **kwargs)
+
+    @swagger_auto_schema(manual_parameters=[EXPAND_PARAMETER])
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
+
+    @swagger_auto_schema(manual_parameters=[EXPAND_PARAMETER])
     @action(methods=("post",), detail=False)
     def _zoek(self, request, *args, **kwargs):
         """

--- a/src/zrc/api/viewsets.py
+++ b/src/zrc/api/viewsets.py
@@ -207,7 +207,12 @@ class ZaakViewSet(
     - `klantcontact` - alle klantcontacten bij een zaak
     """
 
-    queryset = Zaak.objects.prefetch_related("deelzaken").order_by("-pk")
+    queryset = Zaak.objects.prefetch_related(
+        "deelzaken",
+        "rol_set",
+        "zaakobject_set",
+        "zaakinformatieobject_set",
+    ).order_by("-pk")
     serializer_class = ZaakSerializer
     search_input_serializer_class = ZaakZoekSerializer
     filter_backends = (Backend,)

--- a/src/zrc/datamodel/models/core.py
+++ b/src/zrc/datamodel/models/core.py
@@ -323,9 +323,9 @@ class Zaak(ETagMixin, APIMixin, models.Model):
         super().save(*args, **kwargs)
 
     @property
-    def current_status_uuid(self):
+    def current_status(self):
         status = self.status_set.order_by("-datum_status_gezet").first()
-        return status.uuid if status else None
+        return status
 
     @property
     def is_closed(self) -> bool:

--- a/src/zrc/utils/serializers.py
+++ b/src/zrc/utils/serializers.py
@@ -1,0 +1,47 @@
+from django.utils.module_loading import import_string
+
+from rest_framework_nested.serializers import NestedHyperlinkedRelatedField
+
+
+# TODO move to vng-api-common
+class ExpandSerializer(NestedHyperlinkedRelatedField):
+    def __init__(self, *args, **kwargs):
+        # For some reason self.field_name is empty for `many=True`
+        self.name = kwargs.pop("name")
+
+        self.default_serializer = kwargs.pop("default_serializer")
+        self.expanded_serializer = kwargs.pop("expanded_serializer")
+
+        self.default_serializer_kwargs = kwargs.pop("default_serializer_kwargs", {})
+        self.expanded_serializer_kwargs = kwargs.pop("expanded_serializer_kwargs", {})
+
+        # Update the serializer specific kwargs with the kwargs used for all
+        # serializers
+        common_kwargs = kwargs.pop("common_kwargs")
+        self.default_serializer_kwargs.update(common_kwargs)
+        self.expanded_serializer_kwargs.update(common_kwargs)
+
+        kwargs.update(self.default_serializer_kwargs)
+
+        super().__init__(*args, **kwargs)
+
+    def to_representation(self, value):
+        serializer_class = self.default_serializer
+        if isinstance(self.default_serializer, str):
+            serializer_class = import_string(self.default_serializer)
+        serializer = serializer_class(**self.default_serializer_kwargs)
+        serializer.parent = self
+
+        if hasattr(self.context["request"], "query_params"):
+            expand = self.context["request"].query_params.getlist("expand")
+            if self.name in expand:
+                serializer_class = self.expanded_serializer
+                if isinstance(self.expanded_serializer, str):
+                    serializer_class = import_string(self.expanded_serializer)
+                serializer = serializer_class(**self.expanded_serializer_kwargs)
+                serializer.parent = self
+
+        if self.default_serializer_kwargs.get("many", False):
+            value = value.all()
+
+        return serializer.to_representation(value)


### PR DESCRIPTION
issue: VNG-Realisatie/gemma-zaken#1890

Changes:
- Add fields `rollen`, `zaakobjecten` and `zaakinformatieobjecten` to Zaak resource
- Add `expand` query parameter to expand to following fields:
  - Zaak.status
  - Zaak.resultaat
  - Zaak.eigenschappen
  - Zaak.rollen
  - Zaak.zaakobjecten
  - Zaak.zaakinformatieobjecten
