### PR TITLE
 bumpversion zakenapi to 1.3.1 and pin vng api common

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = False
-current_version = 1.3.0
+current_version = 1.3.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(rc|alpha))+(?P<build>\d+))?
 serialize =
 	{major}.{minor}.{patch}-{release}{build}

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Zaken API
 =========
 
-:Version: 1.3.0
+:Version: 1.3.1
 :Source: https://github.com/VNG-Realisatie/zaken-api
 :Keywords: zaken, zaakgericht werken, GEMMA, RGBZ, ZRC
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zrc",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "zrc referentie implementatie API",
   "directories": {
     "doc": "doc"

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -28,7 +28,7 @@ djangorestframework-camel-case
 drf_spectacular
 drf-writable-nested
 
-vng_api_common==2.0.0
+vng_api_common==2.0.1
 gemma-zds-client
 
 # monitoring

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -213,7 +213,7 @@ uritemplate==4.1.1
     # via drf-spectacular
 urllib3==1.26.11
     # via requests
-vng-api-common==2.0.0
+vng-api-common==2.0.1
     # via -r requirements/base.in
 webencodings==0.5.1
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -349,7 +349,7 @@ urllib3==1.26.11
     # via
     #   -r requirements/base.txt
     #   requests
-vng-api-common==2.0.0
+vng-api-common==2.0.1
     # via -r requirements/base.txt
 waitress==2.1.2
     # via webtest

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -443,7 +443,7 @@ urllib3==1.26.11
     # via
     #   -r requirements/ci.txt
     #   requests
-vng-api-common==2.0.0
+vng-api-common==2.0.1
     # via -r requirements/ci.txt
 waitress==2.1.2
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -298,7 +298,7 @@ urllib3==1.26.11
     #   requests
 uwsgi==2.0.20
     # via -r requirements/production.in
-vng-api-common==2.0.0
+vng-api-common==2.0.1
     # via -r requirements/base.txt
 webencodings==0.5.1
     # via

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Zaken API
-  version: 1.3.0
+  version: 1.3.1
   description: |
     Een API om een zaakregistratiecomponent (ZRC) te benaderen.
 

--- a/src/zrc/api/tests/test_dso_api_strategy.py
+++ b/src/zrc/api/tests/test_dso_api_strategy.py
@@ -23,7 +23,7 @@ class DSOApiStrategyTests(APITestCase):
     @override_settings(ROOT_URLCONF="zrc.api.tests.test_urls")
     def test_api_24_version_header(self):
         response = self.client.get("/test-view")
-        self.assertEqual(response["API-version"], "1.3.0")
+        self.assertEqual(response["API-version"], "1.3.1")
 
 
 class DSOApi50Tests(APITestCase):

--- a/src/zrc/conf/includes/api.py
+++ b/src/zrc/conf/includes/api.py
@@ -2,7 +2,7 @@ import os
 
 from vng_api_common.conf.api import *  # noqa - imports white-listed
 
-API_VERSION = "1.3.0"
+API_VERSION = "1.3.1"
 
 REST_FRAMEWORK = BASE_REST_FRAMEWORK.copy()
 REST_FRAMEWORK["PAGE_SIZE"] = 100


### PR DESCRIPTION
- pin vng-api-common requirement to 2.0.1