### PR TITLE
remove standard prefix from server url

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -14723,7 +14723,7 @@ components:
       bearerFormat: JWT
       scheme: bearer
 servers:
-  - url: https://zaken-api.test.vng.cloud/api/v1
+  - url: https://zaken-api.test.vng.cloud
 tags:
   - name: klantcontacten
     description: ''

--- a/src/zrc/conf/includes/api.py
+++ b/src/zrc/conf/includes/api.py
@@ -12,8 +12,7 @@ DOCUMENTATION_INFO_MODULE = "zrc.api.schema"
 SPECTACULAR_SETTINGS = BASE_SPECTACULAR_SETTINGS.copy()
 SPECTACULAR_SETTINGS.update(
     {
-        "SERVERS": [{"url": "https://zaken-api.test.vng.cloud/api/v1"}],
-        # todo remove this line below when deploying to production
+        "SERVERS": [{"url": "https://zaken-api.test.vng.cloud"}],
         "SORT_OPERATION_PARAMETERS": False,
     }
 )


### PR DESCRIPTION
verwijder dubbele 'api/v1' op redoc pagina bij bijvoorbeeld request body url